### PR TITLE
set mruby_root more flexibly

### DIFF
--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ngx_addon_name=ngx_http_mruby_module
-mruby_root=../../vendors
+mruby_root=$ngx_addon_dir/vendors
 
 HTTP_MODULES="$HTTP_MODULES ngx_http_mruby_module"
 


### PR DESCRIPTION
Hi, ngx_mruby/config includes the following line.

```
mruby_root=../../vendors
```

Still the compilation of ngx_mruby with make in ngx_mruby succeeds.
But the compilation fails in the following situation.

``` bash
$ ls
nginx-1.3.7 ngx_mruby
$ cd ngx_mruby
$ make libmruby.a
$ cd ../nginx-1.3.7
$ ./configure --add-module=../ngx_mruby
$ make
            ・
            ・
            ・
../ngx_mruby/ngx_http_mruby_module.c:27:19: fatal error: mruby.h: No such file or directory
compilation terminated.
make[1]: *** [objs/addon/ngx_mruby/ngx_http_mruby_module.o] Error 1
make[1]: Leaving directory `/home/bokko/nginx/nginx-1.3.7'
make: *** [build] Error 2
$
```

This patch makes mruby_root flexible. Thus, the compilation should succeed in every situations.
