### PR TITLE
use '.' instead of 'source'

### DIFF
--- a/config
+++ b/config
@@ -16,5 +16,5 @@ CORE_LIBS="$CORE_LIBS $mruby_root/mrblib/mrblib.o $mruby_root/lib/libmruby.a -lm
 CORE_INCS="$CORE_INCS $mruby_root/src $mruby_root/include"
 
 if [ -f $ngx_addon_dir/mrbgems_config ]; then
-    source $ngx_addon_dir/mrbgems_config
+    . $ngx_addon_dir/mrbgems_config
 fi


### PR DESCRIPTION
Hi, I found the true cause of #6 in my environment . This cause is that dash does not understand 'source'.
This problem seems to occur in all linux distributions adopts dash as default shell.(For example, Ubuntu, Mint)

``` sh
$ ./configure --with-pcre --add-module=../ngx_mruby
adding module in ../ngx_mruby
./configure: 20: ../ngx_mruby/config: source: not found
$
```

'.' is equivalent to 'source' and still works in dash.
