### PR TITLE
fix invalid parameter type

### DIFF
--- a/ngx_http_mruby_request.c
+++ b/ngx_http_mruby_request.c
@@ -50,7 +50,7 @@ static mrb_value ngx_mrb_set_content_type(mrb_state *mrb, mrb_value self)
 
     str = (u_char *)RSTRING_PTR(arg);
     //ngx_str_set(&r->headers_out.content_type, str);
-    r->headers_out.content_type.len = strlen(str) + 1;
+    r->headers_out.content_type.len = ngx_strlen(str) + 1;
     r->headers_out.content_type.data = (u_char *)str;
 
     return self;
@@ -59,7 +59,7 @@ static mrb_value ngx_mrb_set_content_type(mrb_state *mrb, mrb_value self)
 static mrb_value ngx_mrb_get_request_uri(mrb_state *mrb, mrb_value self)
 {
     ngx_http_request_t *r = ngx_mrb_get_request();
-    return mrb_str_new2(mrb, &r->uri);
+    return mrb_str_new2(mrb, (const char *)r->uri.data);
 }
 
 static mrb_value ngx_mrb_set_request_uri(mrb_state *mrb, mrb_value self)


### PR DESCRIPTION
1. str is u_char, but strlen receives const char *(ngx_strlen casts const char \* internally)
2. mrb_str_new2's second parameter type is const char *, but pass ngx_str_t *

1 and 2 raises the compile errors like the following depending on (default) compiler's flag.

``` sh
../ngx_mruby/ngx_http_mruby_request.c: In function ‘ngx_mrb_set_content_type’:
../ngx_mruby/ngx_http_mruby_request.c:53:5: error: pointer targets in passing argument 1 of ‘strlen’ differ in signedness [-Werror=pointer-sign]
/usr/include/string.h:399:15: note: expected ‘const char *’ but argument is of type ‘u_char *’
../ngx_mruby/ngx_http_mruby_request.c: In function ‘ngx_mrb_get_request_uri’:
../ngx_mruby/ngx_http_mruby_request.c:62:5: error: passing argument 2 of ‘mrb_str_new2’ from incompatible pointer type [-Werror]
../ngx_mruby/mruby/include/mruby.h:203:11: note: expected ‘const char *’ but argument is of type ‘struct ngx_str_t *’
```

Especially 2 is a bug obviously.
