### PR TITLE
fix unneeded increment

### DIFF
--- a/ngx_http_mruby_core.c
+++ b/ngx_http_mruby_core.c
@@ -115,7 +115,7 @@ static mrb_value ngx_mrb_rputs(mrb_state *mrb, mrb_value self)
     out.buf->last_buf   = 1;
 
     r->headers_out.status = NGX_HTTP_OK;
-    r->headers_out.content_length_n += len + 1;
+    r->headers_out.content_length_n = len;
     //r->headers_out.content_type.len = sizeof("text/html") - 1;
     //r->headers_out.content_type.data = (u_char *)"text/html";
 


### PR DESCRIPTION
Default value of r->headers_out.content_length_n is -1.
So this code works all right. But this operation may give a false impression.(For example, for null-character)
