### PR TITLE
comparison between signed and unsigned value

### DIFF
--- a/ngx_http_mruby_core.c
+++ b/ngx_http_mruby_core.c
@@ -189,6 +189,7 @@ static mrb_value ngx_mrb_errlogger(mrb_state *mrb, mrb_value self)
 
     mrb_value *argv;
     mrb_int argc;
+    mrb_int log_level;
     ngx_http_request_t *r = ngx_mrb_get_request();
 
     mrb_get_args(mrb, "*", &argv, &argc);
@@ -203,7 +204,20 @@ static mrb_value ngx_mrb_errlogger(mrb_state *mrb, mrb_value self)
         return self;
     }
 
-    ngx_log_error(mrb_fixnum(argv[0]), r->connection->log, 0, "%s", RSTRING_PTR(argv[1]));
+    log_level = mrb_fixnum(argv[0]);
+
+    if (log_level < 0) {
+        ngx_log_error(NGX_LOG_ERR
+                      , r->connection->log
+                      , 0
+                      , "%s ERROR %s: log level is not positive number"
+                      , MODULE_NAME
+                      , __func__
+        );
+        return self;
+    }
+
+    ngx_log_error((ngx_uint_t)log_level, r->connection->log, 0, "%s", RSTRING_PTR(argv[1]));
 
     return self;
 }


### PR DESCRIPTION
If Nginx.errlogger recives 1st args as negative number, ngx_log_error works incorrectly.
I think that Nginx.errlogger should output error to log in this case.

The following is ngx_log_error implementation.

``` c
void ngx_cdecl
ngx_log_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
    const char *fmt, ...)
{   
    va_list  args;

    if (log->log_level >= level) {
        va_start(args, fmt);
        ngx_log_error_core(level, log, err, fmt, args);
        va_end(args);
    }
}
```

The problem occcurs in the following line.

``` c
    if (log->log_level >= level) {
```

It assumes that log->log_level and level are ngx_uint_t(uintptr_t).
But current ngx_mruby pass 1st arg as mrb_int to ngx_log_error.
If level is negative, level becomes max value of ngx_int_t.(because both values are treated unsigned value in operation between signed and unsgined value)

By the way, -Wsign-compare option warns like following.

```
gx_http_mruby_core.c: In function ‘ngx_mrb_errlogger’:
ngx_http_mruby_core.c:206:5: error: comparison between signed and unsigned integer expressions
```

As mruby does not treats unsigned type, I think this options is necessary.(In my environment, this options is default)
