### PR TITLE
'mruby_cache' is not enabled in (post_read|server_rewrite)_handler

### DIFF
--- a/ngx_http_mruby_module.c
+++ b/ngx_http_mruby_module.c
@@ -126,7 +126,7 @@ typedef struct ngx_http_mruby_loc_conf_t {
  
 static ngx_command_t ngx_http_mruby_commands[] = {
     { ngx_string("mruby_cache"),
-      NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      NGX_HTTP_LOC_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_mruby_loc_conf_t, cached),


### PR DESCRIPTION
Though I noticed that a little while ago, 'mruby_cache' is not enabled in (post_read|server_rewrite)_handler.

Even if 'mruby_cache' is set on in location context, it is not enabled in (post_read|server_rewrite)_handler. In these handlers, 
'mruby_cache' must be in server context.

In detail, mruby_cache is set like following currently.

```
location /mruby {
    mruby_cache on;
    mruby_post_read_handler /scripts/post_read.mrb; # 'mruby_cache' is not enabled(!)
    mruby_server_rewrite_handler /scripts/server_rewrite.mrb; # 'mruby_cache' is not enabled(!)
    mruby_rewrite_handler /scripts/rewrite.mrb; # 'mruby_cache' is enabled
    mruby_access_handler /scripts/access.mrb; # 'mruby_cache' is enabled
    mruby_content_handler /scripts/content.mrb; # 'mruby_cache' is enabled
    mruby_log_handler /scripts/log.mrb; # 'mruby_cache' is enabled
```

After patch this commit, if you describe 'mruby_cache on;' in server context, 

```
server {
    mruby_cache on;
    location /mruby {
        mruby_post_read_handler /scripts/post_read.mrb; # 'mruby_cache' is enabled
        mruby_server_rewrite_handler /scripts/server_rewrite.mrb; # 'mruby_cache' is enabled
        mruby_rewrite_handler /scripts/rewrite.mrb; # 'mruby_cache' is enabled
        mruby_access_handler /scripts/access.mrb;  # 'mruby_cache' is enabled
        mruby_content_handler /scripts/content.mrb; # 'mruby_cache' is enabled
        mruby_log_handler /scripts/log.mrb; # 'mruby_cache' is enabled
```
