### PR TITLE
fix memory corruption error

### DIFF
--- a/ngx_http_mruby_core.c
+++ b/ngx_http_mruby_core.c
@@ -50,7 +50,7 @@ static void ngx_mrb_irep_clean(ngx_mrb_state_t *state)
     mrb_free(state->mrb, state->mrb->irep[state->n]);
 }
 
-ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state)
+ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_flag_t cached)
 {
     ngx_mruby_ctx_t *ctx;
     if (state == NGX_CONF_UNSET_PTR) {
@@ -77,7 +77,9 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state)
         }
     }
     mrb_gc_arena_restore(state->mrb, state->ai);
-    ngx_mrb_irep_clean(state);
+    if (!cached) {
+        ngx_mrb_irep_clean(state);
+    }
     return NGX_OK;
 }
 

--- a/ngx_http_mruby_core.h
+++ b/ngx_http_mruby_core.h
@@ -27,6 +27,6 @@ typedef struct ngx_mrb_state_t {
 } ngx_mrb_state_t;
 
 void ngx_mrb_core_init(mrb_state *mrb, struct RClass *class);
-ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *mrb);
+ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_flag_t cached);
 
 #endif // NGX_HTTP_MRUBY_CORE_H

--- a/ngx_http_mruby_handler.c
+++ b/ngx_http_mruby_handler.c
@@ -27,7 +27,7 @@ ngx_int_t ngx_http_mruby_post_read_handler(ngx_http_request_t *r)
         clcf->post_read_state,
         ngx_http_mruby_state_reinit_from_file
     );
-    return ngx_mrb_run(r, clcf->post_read_state);
+    return ngx_mrb_run(r, clcf->post_read_state, clcf->cached);
 }
 
 ngx_int_t ngx_http_mruby_server_rewrite_handler(ngx_http_request_t *r)
@@ -38,7 +38,7 @@ ngx_int_t ngx_http_mruby_server_rewrite_handler(ngx_http_request_t *r)
         clcf->server_rewrite_state,
         ngx_http_mruby_state_reinit_from_file
     );
-    return ngx_mrb_run(r, clcf->server_rewrite_state);
+    return ngx_mrb_run(r, clcf->server_rewrite_state, clcf->cached);
 }
 
 ngx_int_t ngx_http_mruby_rewrite_handler(ngx_http_request_t *r)
@@ -49,7 +49,7 @@ ngx_int_t ngx_http_mruby_rewrite_handler(ngx_http_request_t *r)
         clcf->rewrite_state,
         ngx_http_mruby_state_reinit_from_file
     );
-    return ngx_mrb_run(r, clcf->rewrite_state);
+    return ngx_mrb_run(r, clcf->rewrite_state, clcf->cached);
 }
 
 ngx_int_t ngx_http_mruby_access_handler(ngx_http_request_t *r)
@@ -60,7 +60,7 @@ ngx_int_t ngx_http_mruby_access_handler(ngx_http_request_t *r)
         clcf->access_state,
         ngx_http_mruby_state_reinit_from_file
     );
-    return ngx_mrb_run(r, clcf->access_state);
+    return ngx_mrb_run(r, clcf->access_state, clcf->cached);
 }
 
 ngx_int_t ngx_http_mruby_content_handler(ngx_http_request_t *r)
@@ -71,7 +71,7 @@ ngx_int_t ngx_http_mruby_content_handler(ngx_http_request_t *r)
         clcf->handler_state,
         ngx_http_mruby_state_reinit_from_file
     );
-    return ngx_mrb_run(r, clcf->handler_state);
+    return ngx_mrb_run(r, clcf->handler_state, clcf->cached);
 }
 
 ngx_int_t ngx_http_mruby_log_handler(ngx_http_request_t *r)
@@ -82,41 +82,41 @@ ngx_int_t ngx_http_mruby_log_handler(ngx_http_request_t *r)
         clcf->log_handler_state,
         ngx_http_mruby_state_reinit_from_file
     );
-    return ngx_mrb_run(r, clcf->log_handler_state);
+    return ngx_mrb_run(r, clcf->log_handler_state, clcf->cached);
 }
 
 ngx_int_t ngx_http_mruby_post_read_inline_handler(ngx_http_request_t *r)
 {
     ngx_http_mruby_loc_conf_t *clcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
-    return ngx_mrb_run(r, clcf->post_read_inline_state);
+    return ngx_mrb_run(r, clcf->post_read_inline_state, 1);
 }
 
 ngx_int_t ngx_http_mruby_server_rewrite_inline_handler(ngx_http_request_t *r)
 {
     ngx_http_mruby_loc_conf_t *clcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
-    return ngx_mrb_run(r, clcf->server_rewrite_inline_state);
+    return ngx_mrb_run(r, clcf->server_rewrite_inline_state, 1);
 }
 
 ngx_int_t ngx_http_mruby_rewrite_inline_handler(ngx_http_request_t *r)
 {
     ngx_http_mruby_loc_conf_t *clcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
-    return ngx_mrb_run(r, clcf->rewrite_inline_state);
+    return ngx_mrb_run(r, clcf->rewrite_inline_state, 1);
 }
 
 ngx_int_t ngx_http_mruby_access_inline_handler(ngx_http_request_t *r)
 {
     ngx_http_mruby_loc_conf_t *clcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
-    return ngx_mrb_run(r, clcf->access_inline_state);
+    return ngx_mrb_run(r, clcf->access_inline_state, 1);
 }
 
 ngx_int_t ngx_http_mruby_content_inline_handler(ngx_http_request_t *r)
 {
     ngx_http_mruby_loc_conf_t *clcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
-    return ngx_mrb_run(r, clcf->content_inline_state);
+    return ngx_mrb_run(r, clcf->content_inline_state, 1);
 }
 
 ngx_int_t ngx_http_mruby_log_inline_handler(ngx_http_request_t *r)
 {
     ngx_http_mruby_loc_conf_t *clcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
-    return ngx_mrb_run(r, clcf->log_inline_state);
+    return ngx_mrb_run(r, clcf->log_inline_state, 1);
 }


### PR DESCRIPTION
If ngx_mrb_irep_clean is called when mruby_cache is on, memory corruption error occurs.
This is the patch for a832892. (#27)
