### PR TITLE
remove return(refs #35 #36)

### DIFF
--- a/example/hello.mrb
+++ b/example/hello.mrb
@@ -1,2 +1,1 @@
 Nginx.rputs(Time.now.to_s + " hello mruby world for nginx.")
-Nginx.return Nginx::NGX_OK


### PR DESCRIPTION
hello.mrb is used the example for mruby_content_handler.
But in this case, ngx_mruby does not return a response.
