### PR TITLE
output a error log when mruby script does not exist for mruby_set

### DIFF
--- a/ngx_http_mruby_directive.c
+++ b/ngx_http_mruby_directive.c
@@ -238,6 +238,11 @@ static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *
         filter_data->state = ngx_http_mruby_mrb_state_from_string(cf->pool, &filter_data->script);
     } 
     if (filter_data->state == NGX_CONF_UNSET_PTR) {
+        if (type == NGX_MRB_CODE_TYPE_FILE) {
+            ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
+                               "failed to load mruby script: %s %s:%d", 
+                               filter_data->script.data, __FUNCTION__, __LINE__);
+        }
         return NGX_CONF_ERROR;
     }
 

--- a/ngx_http_mruby_handler.c
+++ b/ngx_http_mruby_handler.c
@@ -130,6 +130,9 @@ ngx_int_t ngx_http_mruby_set_handler(ngx_http_request_t *r, ngx_str_t *val,
 
     filter_data = data;
     if (!clcf->cached && ngx_http_mruby_state_reinit_from_file(filter_data->state)) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "failed to load mruby script: %s %s:%d", 
+                      filter_data->script.data, __FUNCTION__, __LINE__);
         return NGX_ERROR;
     }
  


### PR DESCRIPTION
A missing mruby script for mruby_set causes a failure of starting nginx.
In this case ngx_mruby should output a error log.
