### PR TITLE
Fix `install` target on OSX

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -60,3 +60,4 @@ generate_gems_config: build_mruby
 	@echo CORE_LIBS=\"\$$CORE_LIBS $(LDFLAGS) $(LIBS)\" > ./mrbgems_config
 	@echo CORE_INCS=\"\$$CORE_INCS $(CFLAGS)\" >> ./mrbgems_config
 
+.PHONY: install


### PR DESCRIPTION
I built `ngx_mruby` on OSX, but `make install` failed because of `INSTALL` file. This PR is a small patch using `.PHONY` in `Makefile.in`.

See also: https://github.com/antirez/redis/issues/495
