### PR TITLE
git checkout build_config.rb after make build_mruby

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ clobber: clean_mruby clean
 
 #   build mruby
 build_mruby:
-	cp build_config.rb $(MRUBY_ROOT)/build_config.rb && cd $(MRUBY_ROOT) && $(RAKE)
+	cp build_config.rb $(MRUBY_ROOT)/build_config.rb && cd $(MRUBY_ROOT) && $(RAKE) && cd $(MRUBY_ROOT) && git checkout build_config.rb
 
 #   clean mruby
 clean_mruby:


### PR DESCRIPTION
I don't want to see any `git diff` in `mruby` directory after `make build_mruby`. This PR is a simple hack.
