### PR TITLE
fix bug(using invalid mruby code)

### DIFF
--- a/src/ngx_http_mruby_filter_handler.c
+++ b/src/ngx_http_mruby_filter_handler.c
@@ -43,7 +43,7 @@ ngx_int_t ngx_http_mruby_header_filter_handler(ngx_http_request_t *r)
     NGX_MRUBY_STATE_REINIT_IF_NOT_CACHED(
         mlcf->cached,
         mmcf->state,
-        mlcf->header_filter_inline_code,
+        mlcf->header_filter_code,
         ngx_http_mruby_state_reinit_from_file
     );
 


### PR DESCRIPTION
**mruby_header_filter** fails when mruby_cache is off. Not use inline mruby code in handler of file. 
