### PR TITLE
Fix unistd.h "Expected 'const char *' on ubuntu"

### DIFF
--- a/src/ngx_http_mruby_handler.c
+++ b/src/ngx_http_mruby_handler.c
@@ -49,7 +49,7 @@ ngx_int_t ngx_http_mruby_content_handler(ngx_http_request_t *r)
             );
             return NGX_ERROR;
         } 
-        if (access(path.data, F_OK) != 0) {
+        if (access((const char *)path.data, F_OK) != 0) {
             ngx_log_error(NGX_LOG_INFO
                 , r->connection->log
                 , 0


### PR DESCRIPTION
This fix

```
/usr/src/ngx_mruby/src/ngx_http_mruby_handler.c:52:9: error: pointer targets in passing argument 1 of ‘access’ differ in signedness [-Werror=pointer-sign]
         if (access(path.data, F_OK) != 0) {
         ^
In file included from src/os/unix/ngx_linux_config.h:20:0,
                 from src/core/ngx_config.h:26,
                 from src/http/ngx_http.h:12,
                 from /usr/src/ngx_mruby/src/ngx_http_mruby_handler.h:11,
                 from /usr/src/ngx_mruby/src/ngx_http_mruby_handler.c:7:
/usr/include/unistd.h:287:12: note: expected ‘const char *’ but argument is of type ‘u_char *’
 extern int access (const char *__name, int __type) __THROW __nonnull ((1));
            ^
cc1: all warnings being treated as errors
make[1]: *** [objs/addon/src/ngx_http_mruby_handler.o] Error 1
```
