### PR TITLE
use regular macros instead of compatible macros

### DIFF
--- a/src/ngx_http_mruby_connection.c
+++ b/src/ngx_http_mruby_connection.c
@@ -32,6 +32,6 @@ void ngx_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)
     struct RClass *class_conn;
 
     class_conn = mrb_define_class_under(mrb, class, "Connection", mrb->object_class);
-    mrb_define_method(mrb, class_conn, "remote_ip", ngx_mrb_get_conn_var_remote_addr, ARGS_NONE());
-    mrb_define_method(mrb, class_conn, "remote_port", ngx_mrb_get_conn_var_remote_port, ARGS_NONE());
+    mrb_define_method(mrb, class_conn, "remote_ip", ngx_mrb_get_conn_var_remote_addr, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_conn, "remote_port", ngx_mrb_get_conn_var_remote_port, MRB_ARGS_NONE());
 }

--- a/src/ngx_http_mruby_core.c
+++ b/src/ngx_http_mruby_core.c
@@ -631,13 +631,13 @@ void ngx_mrb_core_init(mrb_state *mrb, struct RClass *class)
     mrb_define_const(mrb, class, "LOG_INFO",                        mrb_fixnum_value(NGX_LOG_INFO));
     mrb_define_const(mrb, class, "LOG_DEBUG",                       mrb_fixnum_value(NGX_LOG_DEBUG));
 
-    mrb_define_class_method(mrb, class, "rputs",                        ngx_mrb_rputs,                      ARGS_ANY());
-    mrb_define_class_method(mrb, class, "send_header",                  ngx_mrb_send_header,                ARGS_ANY());
-    mrb_define_class_method(mrb, class, "return",                       ngx_mrb_send_header,                ARGS_ANY());
-    mrb_define_class_method(mrb, class, "errlogger",                    ngx_mrb_errlogger,                  ARGS_ANY());
-    mrb_define_class_method(mrb, class, "module_name",                  ngx_mrb_get_ngx_mruby_name,         ARGS_NONE());
-    mrb_define_class_method(mrb, class, "module_version",               ngx_mrb_get_ngx_mruby_version,      ARGS_NONE());
-    mrb_define_class_method(mrb, class, "nginx_version",                ngx_mrb_get_nginx_version,          ARGS_NONE());
-    mrb_define_class_method(mrb, class, "redirect",                     ngx_mrb_redirect,                   ARGS_ANY());
-    mrb_define_class_method(mrb, class, "remove_global_variable",       ngx_mrb_f_global_remove,            ARGS_REQ(1));
+    mrb_define_class_method(mrb, class, "rputs",                        ngx_mrb_rputs,                      MRB_ARGS_ANY());
+    mrb_define_class_method(mrb, class, "send_header",                  ngx_mrb_send_header,                MRB_ARGS_ANY());
+    mrb_define_class_method(mrb, class, "return",                       ngx_mrb_send_header,                MRB_ARGS_ANY());
+    mrb_define_class_method(mrb, class, "errlogger",                    ngx_mrb_errlogger,                  MRB_ARGS_ANY());
+    mrb_define_class_method(mrb, class, "module_name",                  ngx_mrb_get_ngx_mruby_name,         MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, class, "module_version",               ngx_mrb_get_ngx_mruby_version,      MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, class, "nginx_version",                ngx_mrb_get_nginx_version,          MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, class, "redirect",                     ngx_mrb_redirect,                   MRB_ARGS_ANY());
+    mrb_define_class_method(mrb, class, "remove_global_variable",       ngx_mrb_f_global_remove,            MRB_ARGS_REQ(1));
 }

--- a/src/ngx_http_mruby_request.c
+++ b/src/ngx_http_mruby_request.c
@@ -298,35 +298,35 @@ void ngx_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     struct RClass *class_headers_out;
 
     class_request = mrb_define_class_under(mrb, class, "Request", mrb->object_class);
-    mrb_define_method(mrb, class_request, "content_type=", ngx_mrb_set_content_type, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "content_type", ngx_mrb_get_content_type, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "request_line", ngx_mrb_get_request_request_line, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "request_line=", ngx_mrb_set_request_request_line, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "uri", ngx_mrb_get_request_uri, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "uri=", ngx_mrb_set_request_uri, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "unparsed_uri", ngx_mrb_get_request_unparsed_uri, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "unparsed_uri=", ngx_mrb_set_request_unparsed_uri, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "method", ngx_mrb_get_request_method, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "method=", ngx_mrb_set_request_method, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "protocol", ngx_mrb_get_request_protocol, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "protocol=", ngx_mrb_set_request_protocol, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "args", ngx_mrb_get_request_args, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "args=", ngx_mrb_set_request_args, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "var", ngx_mrb_get_request_var, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "headers_in", ngx_mrb_headers_in_obj, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "headers_out", ngx_mrb_headers_out_obj, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "content_type=", ngx_mrb_set_content_type, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_request, "content_type", ngx_mrb_get_content_type, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "request_line", ngx_mrb_get_request_request_line, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "request_line=", ngx_mrb_set_request_request_line, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_request, "uri", ngx_mrb_get_request_uri, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "uri=", ngx_mrb_set_request_uri, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_request, "unparsed_uri", ngx_mrb_get_request_unparsed_uri, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "unparsed_uri=", ngx_mrb_set_request_unparsed_uri, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_request, "method", ngx_mrb_get_request_method, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "method=", ngx_mrb_set_request_method, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_request, "protocol", ngx_mrb_get_request_protocol, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "protocol=", ngx_mrb_set_request_protocol, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_request, "args", ngx_mrb_get_request_args, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "args=", ngx_mrb_set_request_args, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_request, "var", ngx_mrb_get_request_var, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "headers_in", ngx_mrb_headers_in_obj, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "headers_out", ngx_mrb_headers_out_obj, MRB_ARGS_NONE());
 
-    mrb_define_method(mrb, class_request, "hostname", ngx_mrb_get_request_var_hostname, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "filename", ngx_mrb_get_request_var_filename, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "user", ngx_mrb_get_request_var_user, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "hostname", ngx_mrb_get_request_var_hostname, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "filename", ngx_mrb_get_request_var_filename, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "user", ngx_mrb_get_request_var_user, MRB_ARGS_NONE());
 
     class_headers_in = mrb_define_class_under(mrb, class, "Headers_in", mrb->object_class);
-    mrb_define_method(mrb, class_headers_in, "[]", ngx_mrb_get_request_headers_in, ARGS_ANY());
-    mrb_define_method(mrb, class_headers_in, "[]=", ngx_mrb_set_request_headers_in, ARGS_ANY());
-    mrb_define_method(mrb, class_headers_in, "all", ngx_mrb_get_request_headers_in_hash, ARGS_ANY());
+    mrb_define_method(mrb, class_headers_in, "[]", ngx_mrb_get_request_headers_in, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_headers_in, "[]=", ngx_mrb_set_request_headers_in, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_headers_in, "all", ngx_mrb_get_request_headers_in_hash, MRB_ARGS_ANY());
 
     class_headers_out = mrb_define_class_under(mrb, class, "Headers_out", mrb->object_class);
-    mrb_define_method(mrb, class_headers_out, "[]", ngx_mrb_get_request_headers_out, ARGS_ANY());
-    mrb_define_method(mrb, class_headers_out, "[]=", ngx_mrb_set_request_headers_out, ARGS_ANY());
-    mrb_define_method(mrb, class_headers_out, "all", ngx_mrb_get_request_headers_out_hash, ARGS_ANY());
+    mrb_define_method(mrb, class_headers_out, "[]", ngx_mrb_get_request_headers_out, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_headers_out, "[]=", ngx_mrb_set_request_headers_out, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_headers_out, "all", ngx_mrb_get_request_headers_out_hash, MRB_ARGS_ANY());
 }

--- a/src/ngx_http_mruby_server.c
+++ b/src/ngx_http_mruby_server.c
@@ -26,5 +26,5 @@ void ngx_mrb_server_class_init(mrb_state *mrb, struct RClass *class)
     struct RClass *class_server;
 
     class_server = mrb_define_class_under(mrb, class, "Server", mrb->object_class);
-    mrb_define_method(mrb, class_server, "document_root", ngx_mrb_get_server_var_docroot, ARGS_NONE());
+    mrb_define_method(mrb, class_server, "document_root", ngx_mrb_get_server_var_docroot, MRB_ARGS_NONE());
 }

--- a/src/ngx_http_mruby_var.c
+++ b/src/ngx_http_mruby_var.c
@@ -337,6 +337,6 @@ void ngx_mrb_var_class_init(mrb_state *mrb, struct RClass *class)
     struct RClass *class_var;
 
     class_var = mrb_define_class_under(mrb, class, "Var", mrb->object_class);
-    mrb_define_method(mrb, class_var, "method_missing", ngx_mrb_var_method_missing, ARGS_ANY());
-    mrb_define_method(mrb, class_var, "set", ngx_mrb_var_set_func, ARGS_REQ(2));
+    mrb_define_method(mrb, class_var, "method_missing", ngx_mrb_var_method_missing, MRB_ARGS_ANY());
+    mrb_define_method(mrb, class_var, "set", ngx_mrb_var_set_func, MRB_ARGS_REQ(2));
 }


### PR DESCRIPTION
According to mruby/include/mruby.h,

``` c
/* compatibility macros; will be removed */
#define ARGS_REQ(n)         MRB_ARGS_REQ(n)
#define ARGS_OPT(n)         MRB_ARGS_OPT(n)
#define ARGS_REST()         MRB_ARGS_REST()
#define ARGS_POST(n)        MRB_ARGS_POST()
#define ARGS_KEY(n1,n2)     MRB_ARGS_KEY(n1,n2)
#define ARGS_BLOCK()        MRB_ARGS_BLOCK()
#define ARGS_ANY()          MRB_ARGS_ANY()
#define ARGS_NONE()         MRB_ARGS_NONE()
```
