### PR TITLE
improve error-handling when loading mruby script

### DIFF
--- a/src/ngx_http_mruby_module.c
+++ b/src/ngx_http_mruby_module.c
@@ -821,6 +821,10 @@ static ngx_int_t ngx_http_mruby_shared_state_compile(ngx_conf_t *cf, ngx_mrb_sta
     p = mrb_parse_string(state->mrb, (char *)code->code.string, code->ctx);
   }
 
+  if (p == NULL) {
+    return NGX_ERROR;
+  }
+
   code->proc = mrb_generate_code(state->mrb, p);
   mrb_pool_close(p->pool);
 
@@ -861,6 +865,7 @@ static char *ngx_http_mruby_init_phase(ngx_conf_t *cf, ngx_command_t *cmd, void 
   ngx_http_mruby_main_conf_t *mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_mruby_module);
   ngx_str_t *value;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
 
   if (mmcf->init_code != NULL) {
     return "[Use either 'mruby_init' or 'mruby_init_inline']";
@@ -883,7 +888,11 @@ static char *ngx_http_mruby_init_phase(ngx_conf_t *cf, ngx_command_t *cmd, void 
     }
   }
   mmcf->init_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -893,6 +902,7 @@ static char *ngx_http_mruby_init_inline(ngx_conf_t *cf, ngx_command_t *cmd, void
   ngx_http_mruby_main_conf_t *mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_mruby_module);
   ngx_str_t *value;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
 
   if (mmcf->init_code != NULL) {
     return "is duplicated";
@@ -905,7 +915,11 @@ static char *ngx_http_mruby_init_inline(ngx_conf_t *cf, ngx_command_t *cmd, void
     return NGX_CONF_ERROR;
   }
   mmcf->init_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -916,6 +930,7 @@ static char *ngx_http_mruby_post_read_phase(ngx_conf_t *cf, ngx_command_t *cmd, 
   ngx_http_mruby_loc_conf_t *mlcf;
   ngx_str_t *value;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
 
   mlcf = conf;
 
@@ -935,7 +950,11 @@ static char *ngx_http_mruby_post_read_phase(ngx_conf_t *cf, ngx_command_t *cmd, 
     }
   }
   mlcf->post_read_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -946,6 +965,7 @@ static char *ngx_http_mruby_server_rewrite_phase(ngx_conf_t *cf, ngx_command_t *
   ngx_str_t *value;
   ngx_http_mruby_loc_conf_t *mlcf;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
 
   mlcf = conf;
 
@@ -965,7 +985,11 @@ static char *ngx_http_mruby_server_rewrite_phase(ngx_conf_t *cf, ngx_command_t *
     }
   }
   mlcf->server_rewrite_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -976,6 +1000,7 @@ static char *ngx_http_mruby_rewrite_phase(ngx_conf_t *cf, ngx_command_t *cmd, vo
   ngx_str_t *value;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
  
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_file(cf->pool, &value[1]);
@@ -993,7 +1018,11 @@ static char *ngx_http_mruby_rewrite_phase(ngx_conf_t *cf, ngx_command_t *cmd, vo
     }
   }
   mlcf->rewrite_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1004,6 +1033,7 @@ static char *ngx_http_mruby_access_phase(ngx_conf_t *cf, ngx_command_t *cmd, voi
   ngx_str_t *value;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
  
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_file(cf->pool, &value[1]);
@@ -1021,7 +1051,11 @@ static char *ngx_http_mruby_access_phase(ngx_conf_t *cf, ngx_command_t *cmd, voi
     }
   }
   mlcf->access_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1032,6 +1066,7 @@ static char *ngx_http_mruby_content_phase(ngx_conf_t *cf, ngx_command_t *cmd, vo
   ngx_str_t *value;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_file(cf->pool, &value[1]);
@@ -1049,7 +1084,11 @@ static char *ngx_http_mruby_content_phase(ngx_conf_t *cf, ngx_command_t *cmd, vo
     }
   }
   mlcf->content_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1060,6 +1099,7 @@ static char *ngx_http_mruby_log_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *
   ngx_str_t *value;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_file(cf->pool, &value[1]);
@@ -1077,7 +1117,11 @@ static char *ngx_http_mruby_log_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *
     }
   }
   mlcf->log_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1088,6 +1132,7 @@ static char *ngx_http_mruby_post_read_inline(ngx_conf_t *cf, ngx_command_t *cmd,
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_string(cf->pool, &value[1]);
@@ -1095,7 +1140,11 @@ static char *ngx_http_mruby_post_read_inline(ngx_conf_t *cf, ngx_command_t *cmd,
     return NGX_CONF_ERROR;
   }
   mlcf->post_read_inline_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1106,6 +1155,7 @@ static char *ngx_http_mruby_server_rewrite_inline(ngx_conf_t *cf, ngx_command_t 
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_string(cf->pool, &value[1]);
@@ -1113,7 +1163,11 @@ static char *ngx_http_mruby_server_rewrite_inline(ngx_conf_t *cf, ngx_command_t 
     return NGX_CONF_ERROR;
   }
   mlcf->server_rewrite_inline_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1124,6 +1178,7 @@ static char *ngx_http_mruby_rewrite_inline(ngx_conf_t *cf, ngx_command_t *cmd, v
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_string(cf->pool, &value[1]);
@@ -1131,7 +1186,11 @@ static char *ngx_http_mruby_rewrite_inline(ngx_conf_t *cf, ngx_command_t *cmd, v
     return NGX_CONF_ERROR;
   }
   mlcf->rewrite_inline_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1142,6 +1201,7 @@ static char *ngx_http_mruby_access_inline(ngx_conf_t *cf, ngx_command_t *cmd, vo
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_string(cf->pool, &value[1]);
@@ -1149,7 +1209,11 @@ static char *ngx_http_mruby_access_inline(ngx_conf_t *cf, ngx_command_t *cmd, vo
     return NGX_CONF_ERROR;
   }
   mlcf->access_inline_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1160,6 +1224,7 @@ static char *ngx_http_mruby_content_inline(ngx_conf_t *cf, ngx_command_t *cmd, v
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_string(cf->pool, &value[1]);
@@ -1167,7 +1232,11 @@ static char *ngx_http_mruby_content_inline(ngx_conf_t *cf, ngx_command_t *cmd, v
     return NGX_CONF_ERROR;
   }
   mlcf->content_inline_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1178,6 +1247,7 @@ static char *ngx_http_mruby_log_inline(ngx_conf_t *cf, ngx_command_t *cmd, void 
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_string(cf->pool, &value[1]);
@@ -1185,7 +1255,11 @@ static char *ngx_http_mruby_log_inline(ngx_conf_t *cf, ngx_command_t *cmd, void 
     return NGX_CONF_ERROR;
   }
   mlcf->log_inline_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
 
   return NGX_CONF_OK;
 }
@@ -1196,6 +1270,7 @@ static char *ngx_http_mruby_body_filter_phase(ngx_conf_t *cf, ngx_command_t *cmd
   ngx_str_t *value;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
   ngx_mrb_code_t *code;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_file(cf->pool, &value[1]);
@@ -1212,7 +1287,11 @@ static char *ngx_http_mruby_body_filter_phase(ngx_conf_t *cf, ngx_command_t *cmd
       return NGX_CONF_ERROR;
     }
   }
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
   mlcf->body_filter_code = code;
   mmcf->enabled_header_filter = 1;
   mmcf->enabled_body_filter   = 1;
@@ -1227,6 +1306,7 @@ static char *ngx_http_mruby_body_filter_inline(ngx_conf_t *cf, ngx_command_t *cm
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_http_mruby_loc_conf_t *mlcf = conf;
+  ngx_int_t rc;
 
   value = cf->args->elts;
   code  = ngx_http_mruby_mrb_code_from_string(cf->pool, &value[1]);
@@ -1234,7 +1314,11 @@ static char *ngx_http_mruby_body_filter_inline(ngx_conf_t *cf, ngx_command_t *cm
     return NGX_CONF_ERROR;
   }
   mlcf->body_filter_inline_code = code;
-  ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  rc = ngx_http_mruby_shared_state_compile(cf, mmcf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
   mmcf->enabled_header_filter = 1;
   mmcf->enabled_body_filter   = 1;
   mlcf->body_filter_handler   = cmd->post;
@@ -1251,6 +1335,7 @@ static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *
   ndk_set_var_t filter;
   ngx_http_mruby_set_var_data_t *filter_data;
   ngx_http_mruby_main_conf_t *mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_mruby_module);
+  ngx_int_t rc;
 
   value  = cf->args->elts;
   target = value[1];
@@ -1273,7 +1358,15 @@ static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *
   else {
     filter_data->code = ngx_http_mruby_mrb_code_from_string(cf->pool, &filter_data->script);
   } 
-  ngx_http_mruby_shared_state_compile(cf, filter_data->state, filter_data->code);
+  rc = ngx_http_mruby_shared_state_compile(cf, filter_data->state, filter_data->code);
+  if (rc != NGX_OK) {
+    if (type == NGX_MRB_CODE_TYPE_FILE) {
+      ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_file(%s) open failed", value[1].data);
+    } else {
+      ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    }
+    return NGX_CONF_ERROR;
+  }
   if (filter_data->code == NGX_CONF_UNSET_PTR) {
     if (type == NGX_MRB_CODE_TYPE_FILE) {
       ngx_conf_log_error(NGX_LOG_ERR


### PR DESCRIPTION
The current implementation doesn't check the return value `ngx_http_mruby_shared_state_compile`.
e.g. in the following nginx.conf, nginx outputs no error log.

``` nginx
location /mruby {
    mruby_content_handler "Nginx.rputs('hoge\n')";
}
```
