### PR TITLE
change to use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "mruby"]
 	path = mruby
-	url = git://github.com/mruby/mruby.git
+	url = https://github.com/mruby/mruby.git
 
 [submodule "ngx_devel_kit"]
 	path = dependence/ngx_devel_kit

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get -y install libcgroup-dev
 RUN apt-get -y install make
 RUN apt-get -y install libpcre3 libpcre3-dev
 
-RUN cd /usr/local/src/ && git clone git://github.com/matsumoto-r/ngx_mruby.git
+RUN cd /usr/local/src/ && git clone https://github.com/matsumoto-r/ngx_mruby.git
 ENV NGINX_CONFIG_OPT_ENV --with-http_stub_status_module --prefix=/usr/local/nginx
 RUN cd /usr/local/src/ngx_mruby && sh build.sh && make install
 


### PR DESCRIPTION
Sorry to bother you again.
For same reason in [this PR](https://github.com/matsumoto-r/mod_mruby/pull/60), I would rather prefer to use `https://` protocol.
