### PR TITLE
fix partial match of header name

### DIFF
--- a/src/ngx_http_mruby_request.c
+++ b/src/ngx_http_mruby_request.c
@@ -140,6 +140,7 @@ static mrb_value ngx_mrb_get_request_header(mrb_state *mrb, ngx_list_t *headers)
 {
   mrb_value mrb_key;
   u_char *key;
+  size_t key_len;
   ngx_uint_t i;
   ngx_list_part_t *part;
   ngx_table_elt_t *header;
@@ -147,6 +148,7 @@ static mrb_value ngx_mrb_get_request_header(mrb_state *mrb, ngx_list_t *headers)
   mrb_get_args(mrb, "o", &mrb_key);
 
   key = (u_char *)mrb_str_to_cstr(mrb, mrb_key);
+  key_len = RSTRING_LEN(mrb_key);
   part = &headers->part;
   header = part->elts;
 
@@ -161,7 +163,7 @@ static mrb_value ngx_mrb_get_request_header(mrb_state *mrb, ngx_list_t *headers)
       i = 0;
     }
 
-    if (ngx_strncasecmp(key, header[i].key.data, header[i].key.len) == 0) {
+    if (ngx_strncasecmp(header[i].key.data, key, key_len) == 0) {
       return mrb_str_new(mrb, (const char *)header[i].value.data,
           header[i].value.len);
     }
@@ -201,7 +203,7 @@ static ngx_int_t ngx_mrb_set_request_header(mrb_state *mrb, ngx_list_t *headers,
       i = 0;
     }
 
-    if (ngx_strncasecmp(key, header[i].key.data, header[i].key.len) == 0) {
+    if (ngx_strncasecmp(header[i].key.data, key, key_len) == 0) {
       header[i].value.data = val;
       header[i].value.len = val_len;
       return NGX_OK;


### PR DESCRIPTION
# 概要

Nginx::Request#headers_in[] でヘッダーの値を取得しようとした場合、別のヘッダーの値が取得されてしまいます。
例えば、リクエストヘッダーが以下の場合に、Accept-Language ヘッダーの値を取得しようとすると、その戻り値が Accept ヘッダーの値になってしまいます。
- request header

```
Accept: text/html
Accept-Encoding: gzip,deflate,sdch
Accept-Language: ja,en-US;q=0.8,en;q=0.6
```
- code

```
req = Nginx::Request.new
Nginx::rputs "headers_in['Accept-Language']: #{req.headers_in['Accept-Language']}"    # => text/html
Nginx::rputs "headers_in['Accept-Encoding']: #{req.headers_in['Accept-Encoding']}"    # => text/html
```
# 問題箇所

ngx_mrb_get_request_header() にて、ヘッダー名の比較が前方一致比較になっています。

＃ 対処
ヘッダー名の比較では完全一致比較をするように修正しています。
また、取得処だけでなく、ヘッダー値をセットする場合の比較処理も修正しています。
