### PR TITLE
add mysql support

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -33,6 +33,9 @@ MRuby::Build.new do |conf|
   # use markdown on ngx_mruby
   # conf.gem :github => 'matsumoto-r/mruby-discount'
 
+  # use mysql on ngx_mruby
+  conf.gem :github => 'mattn/mruby-mysql'
+
   # have GeoIPCity.dat
   # conf.gem :github => 'matsumoto-r/mruby-geoip'
 


### PR DESCRIPTION
Hello,

I'm not sure the best way to add mysql support to ngx_mruby.

I also needed to modify mruby/mrbgems/default.gembox:

```
conf.gem :core => "mruby-mysql"
```

Since this is another repo, can you tell me how make these changes?
(not totally sure what a `core` gem means)

Thanks
Keenan
