### PR TITLE
Add stream ip and port methods

### DIFF
--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -152,6 +152,14 @@ static mrb_value ngx_stream_mrb_remote_ip(mrb_state *mrb, mrb_value self)
   return mrb_str_new(mrb, (const char *)s->connection->addr_text.data, s->connection->addr_text.len);
 }
 
+static mrb_value ngx_stream_mrb_local_ip_port(mrb_state *mrb, mrb_value self)
+{
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
+
+  return mrb_str_new(mrb, (const char *)s->connection->listening->addr_text.data, s->connection->listening->addr_text.len);
+}
+
 static mrb_value ngx_stream_mrb_local_ip(mrb_state *mrb, mrb_value self)
 {
   ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
@@ -209,21 +217,28 @@ void ngx_stream_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_method(mrb, class_conn, "upstream_server=", ngx_stream_mrb_upstream_set_server, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_conn, "stream_status", ngx_stream_mrb_connection_get_status, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "stream_status=", ngx_stream_mrb_connection_status, MRB_ARGS_REQ(1));
+
   mrb_define_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "remote_addr", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_port, MRB_ARGS_NONE());
+
   mrb_define_method(mrb, class_conn, "local_ip", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "local_addr", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "local_port", ngx_stream_mrb_local_port, MRB_ARGS_NONE());
-  mrb_define_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_port, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "local_ip_port", ngx_stream_mrb_local_ip_port, MRB_ARGS_NONE());
+
   mrb_define_method(mrb, class_conn, "proxy_protocol_ip", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "proxy_protocol_addr", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
 
   mrb_define_class_method(mrb, class_conn, "local_ip", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "local_addr", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "local_port", ngx_stream_mrb_local_port, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class_conn, "local_ip_port", ngx_stream_mrb_local_ip_port, MRB_ARGS_NONE());
+
   mrb_define_class_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_port, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "remote_addr", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
+
   mrb_define_class_method(mrb, class_conn, "proxy_protocol_ip", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "proxy_protocol_addr", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "stream_status", ngx_stream_mrb_connection_get_status, MRB_ARGS_NONE());

--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -152,6 +152,18 @@ static mrb_value ngx_stream_mrb_remote_ip(mrb_state *mrb, mrb_value self)
   return mrb_str_new(mrb, (const char *)s->connection->addr_text.data, s->connection->addr_text.len);
 }
 
+static mrb_value ngx_stream_mrb_local_ip(mrb_state *mrb, mrb_value self)
+{
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
+  u_char ipaddr_txt[NGX_SOCKADDR_STRLEN];
+  mrb_int ipaddr_len;
+
+  ipaddr_len = ngx_sock_ntop(s->connection->local_sockaddr, s->connection->local_socklen, ipaddr_txt, NGX_SOCKADDR_STRLEN, 0);
+
+  return mrb_str_new(mrb, (char *)ipaddr_txt, ipaddr_len);
+}
+
 static in_port_t get_in_port(struct sockaddr *sa)
 {
     if (sa->sa_family == AF_INET) {
@@ -199,10 +211,15 @@ void ngx_stream_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_method(mrb, class_conn, "stream_status=", ngx_stream_mrb_connection_status, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "remote_addr", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "local_ip", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "local_addr", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "local_port", ngx_stream_mrb_local_port, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_port, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "proxy_protocol_ip", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "proxy_protocol_addr", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
+
+  mrb_define_class_method(mrb, class_conn, "local_ip", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class_conn, "local_addr", ngx_stream_mrb_local_ip, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "local_port", ngx_stream_mrb_local_port, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_port, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());

--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -152,6 +152,31 @@ static mrb_value ngx_stream_mrb_remote_ip(mrb_state *mrb, mrb_value self)
   return mrb_str_new(mrb, (const char *)s->connection->addr_text.data, s->connection->addr_text.len);
 }
 
+static in_port_t get_in_port(struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET) {
+        return (((struct sockaddr_in*)sa)->sin_port);
+    }
+
+    return (((struct sockaddr_in6*)sa)->sin6_port);
+}
+
+static mrb_value ngx_stream_mrb_local_port(mrb_state *mrb, mrb_value self)
+{
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
+
+  return mrb_fixnum_value(mrb, ntohs(get_in_port(s->connection->local_sockaddr)));
+}
+
+static mrb_value ngx_stream_mrb_remote_port(mrb_state *mrb, mrb_value self)
+{
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
+
+  return mrb_fixnum_value(mrb, ntohs(get_in_port(s->connection->sockaddr)));
+}
+
 static mrb_value ngx_stream_mrb_proxy_protocol_addr(mrb_state *mrb, mrb_value self)
 {
   ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
@@ -174,6 +199,8 @@ void ngx_stream_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_method(mrb, class_conn, "stream_status=", ngx_stream_mrb_connection_status, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "remote_addr", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "local_port", ngx_stream_mrb_local_port, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_rpot, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "proxy_protocol_ip", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "proxy_protocol_addr", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());

--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -166,7 +166,7 @@ static mrb_value ngx_stream_mrb_local_port(mrb_state *mrb, mrb_value self)
   ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
   ngx_stream_session_t *s = ictx->s;
 
-  return mrb_fixnum_value(mrb, ntohs(get_in_port(s->connection->local_sockaddr)));
+  return mrb_fixnum_value(ntohs(get_in_port(s->connection->local_sockaddr)));
 }
 
 static mrb_value ngx_stream_mrb_remote_port(mrb_state *mrb, mrb_value self)
@@ -174,7 +174,7 @@ static mrb_value ngx_stream_mrb_remote_port(mrb_state *mrb, mrb_value self)
   ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
   ngx_stream_session_t *s = ictx->s;
 
-  return mrb_fixnum_value(mrb, ntohs(get_in_port(s->connection->sockaddr)));
+  return mrb_fixnum_value(ntohs(get_in_port(s->connection->sockaddr)));
 }
 
 static mrb_value ngx_stream_mrb_proxy_protocol_addr(mrb_state *mrb, mrb_value self)
@@ -200,9 +200,11 @@ void ngx_stream_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "remote_addr", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "local_port", ngx_stream_mrb_local_port, MRB_ARGS_NONE());
-  mrb_define_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_rpot, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_port, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "proxy_protocol_ip", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "proxy_protocol_addr", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class_conn, "local_port", ngx_stream_mrb_local_port, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class_conn, "remote_port", ngx_stream_mrb_remote_port, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "remote_addr", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, class_conn, "proxy_protocol_ip", ngx_stream_mrb_proxy_protocol_addr, MRB_ARGS_NONE());

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -56,8 +56,10 @@ stream {
   server {
       listen 127.0.0.1:12348;
       mruby_stream_code '
-        Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "local_port is #{Nginx::Stream::Connection.local_port} remote_port is #{Nginx::Stream::Connection.remote_port}"
-        Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT if Nginx::Stream::Connection.local_port != 12348
+        Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "local is #{Nginx::Stream::Connection.local_ip}:#{Nginx::Stream::Connection.local_port} remote_port is #{Nginx::Stream::Connection.remote_ip}:#{Nginx::Stream::Connection.remote_port}"
+        if Nginx::Stream::Connection.local_port != 12348 && Nginx::Stream::Connection.local_ip != "127.0.0.1"
+          Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT
+        end
       ';
       proxy_pass static_server0;
   }

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -5,6 +5,9 @@ stream {
   upstream dynamic_server1 {
     server 127.0.0.1:58081;
   }
+  upstream static_server0 {
+    server 127.0.0.1:58080;
+  }
 
   mruby_stream_init_code '
     p "ngx_mruby: STREAM: mruby_stream_init_code"
@@ -48,6 +51,15 @@ stream {
         end
       ';
       proxy_pass dynamic_server1;
+  }
+
+  server {
+      listen 127.0.0.1:12348;
+      mruby_stream_code '
+        Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "local_port is #{Nginx::Stream::Connection.local_port} remote_port is #{Nginx::Stream::Connection.remote_port}"
+        Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT if Nginx::Stream::Connection.local_port != 12348
+      ';
+      proxy_pass static_server0;
   }
 }
 

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -63,5 +63,16 @@ stream {
       ';
       proxy_pass static_server0;
   }
+
+  server {
+      listen 127.0.0.1:12349;
+      mruby_stream_code '
+        Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "local_ip_port is #{Nginx::Stream::Connection.local_ip_port}"
+        if Nginx::Stream::Connection.local_ip_port != "127.0.0.1:12349"
+          Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT
+        end
+      ';
+      proxy_pass static_server0;
+  }
 }
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -332,7 +332,7 @@ t.assert('ngx_mruby - rack base', 'location /rack_base_env') do
 end
 
 t.assert('ngx_mruby - rack base', 'method POST, location /rack_base_env') do
-  req_body = 'Hello' 
+  req_body = 'Hello'
   res = HttpRequest.new.post base + '/rack_base_env', req_body, {"Content-Type" => "text/plain; charset=us-ascii", "Content-Length" => req_body.size}
   res_body = JSON.parse res["body"]
   puts res_body
@@ -515,7 +515,7 @@ end
 
 t.assert('ngx_mruby - Throw my own exception for issue 238', 'location /issue_238') do
   res = HttpRequest.new.get base + '/issue_238'
-  t.assert_equal 500, res.code 
+  t.assert_equal 500, res.code
 end
 
 t.assert('ngx_mruby - access_handler in server scope', 'location /access_handler_in_server_scope') do
@@ -541,6 +541,7 @@ end
 if nginx_version.split(".")[1].to_i >= 10 || (nginx_version.split(".")[1].to_i == 9 && nginx_version.split(".")[2].to_i >= 6)
   base1 = "http://127.0.0.1:12345"
   base2 = "http://127.0.0.1:12346"
+  base3 = "http://127.0.0.1:12348"
   t.assert('ngx_mruby - stream tcp load balancer', '127.0.0.1:12345 to 127.0.0.1:58080 which changed from 127.0.0.1:58081 by mruby') do
     res = HttpRequest.new.get(base1 + '/mruby')
     t.assert_equal 'Hello ngx_mruby world!', res["body"]
@@ -548,6 +549,10 @@ if nginx_version.split(".")[1].to_i >= 10 || (nginx_version.split(".")[1].to_i =
   t.assert('ngx_mruby - stream tcp load balancer', '127.0.0.1:12346 to 127.0.0.1:58081 which changed from 127.0.0.1:58080 by mruby') do
     res = HttpRequest.new.get(base2 + '/')
     t.assert_equal 'proxy test ok', res["body"]
+  end
+  t.assert('ngx_mruby - stream tcp port') do
+    res = HttpRequest.new.get(base3 + '/mruby')
+    t.assert_equal 'Hello ngx_mruby world!', res["body"]
   end
 end
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -539,9 +539,12 @@ end
 # nginx stream test verison 1.9.6 later
 #
 if nginx_version.split(".")[1].to_i >= 10 || (nginx_version.split(".")[1].to_i == 9 && nginx_version.split(".")[2].to_i >= 6)
+
   base1 = "http://127.0.0.1:12345"
   base2 = "http://127.0.0.1:12346"
   base3 = "http://127.0.0.1:12348"
+  base4 = "http://127.0.0.1:12349"
+
   t.assert('ngx_mruby - stream tcp load balancer', '127.0.0.1:12345 to 127.0.0.1:58080 which changed from 127.0.0.1:58081 by mruby') do
     res = HttpRequest.new.get(base1 + '/mruby')
     t.assert_equal 'Hello ngx_mruby world!', res["body"]
@@ -552,6 +555,10 @@ if nginx_version.split(".")[1].to_i >= 10 || (nginx_version.split(".")[1].to_i =
   end
   t.assert('ngx_mruby - stream tcp port') do
     res = HttpRequest.new.get(base3 + '/mruby')
+    t.assert_equal 'Hello ngx_mruby world!', res["body"]
+  end
+  t.assert('ngx_mruby - stream tcp ip port text') do
+    res = HttpRequest.new.get(base4 + '/mruby')
     t.assert_equal 'Hello ngx_mruby world!', res["body"]
   end
 end


### PR DESCRIPTION
Add the following methods for ip and port of stream module:

- `Nginx::Stream::Connection#{local_ip,local_ip_port,local_port,remote_port}`
- `Nginx::Stream::Connection.{local_ip,local_ip_port,local_port,remote_port}`