### PR TITLE
Remove dependency to mruby-io

### DIFF
--- a/mrbgems/rack-based-api/mrblib/rack.rb
+++ b/mrbgems/rack-based-api/mrblib/rack.rb
@@ -44,7 +44,12 @@ module Kernel
 
     class LazyStringIO
       # Avoid naming conflicts with Kernel methods introduced by mruby-io
-      undef_method :gets, :getc
+      [
+        :gets,
+        :getc,
+      ].each do |m|
+        undef_method m if Kernel.respond_to?(m)
+      end
 
       def initialize(proc)
         @proc = proc


### PR DESCRIPTION
If I remove `iij/mruby-io` from build_config.rb, it raise NameError.

```
ngx_mruby/mrbgems/rack-based-api/mrblib/rack.rb:51: undefined method 'gets' for class 'Kernel::Rack::LazyStringIO' (NameError)
```

I think `iij/mruby-io` is optional mgem.
I hope to remove dependency to mruby-io.

### Note

Sorry, I don't know how to test of this gem.