### PR TITLE
support to ip base TLS handshake

### DIFF
--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -2537,17 +2537,17 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
   servername = SSL_get_servername(ssl_conn, TLSEXT_NAMETYPE_host_name);
   if (servername == NULL) {
+    host.len = 0;
     ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: SSL server name NULL");
-    return 1;
+  } else {
+    host.len = ngx_strlen(servername);
+    if (host.len == 0) {
+      ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: host len == 0");
+      return 1;
+    }
+    host.data = (u_char *)servername;
+    ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: servername \"%V\"", &host);
   }
-
-  host.len = ngx_strlen(servername);
-  if (host.len == 0) {
-    ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: host len == 0");
-    return 1;
-  }
-  host.data = (u_char *)servername;
-  ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: servername \"%V\"", &host);
 
   mscf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_mruby_module);
   if (NULL == mscf) {

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -117,6 +117,24 @@ http {
     }
 
     server {
+        listen       58088 ssl;
+        server_name  _;
+        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_certificate     __NGXDOCROOT__/dummy.crt;
+        ssl_certificate_key __NGXDOCROOT__/dummy.key;
+
+        mruby_ssl_handshake_handler_code '
+          ssl = Nginx::SSL.new
+          Userdata.new.ssl_servername = ssl.servername.empty? ? "servername is empty" : ssl.servername
+        ';
+
+        location /servername {
+            mruby_content_handler_code "Nginx.rputs Userdata.new.ssl_servername.to_s";
+        }
+    }
+
+    server {
         listen       58081;
         server_name  localhost;
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -494,6 +494,13 @@ t.assert('ngx_mruby - Nginx::SSL.errlogger') do
   t.assert_true error_log.include? 'Servername is localhost while SSL handshaking'
 end
 
+t.assert('ngx_mruby - get ssl server name') do
+  res = `echo "GET /servername" | openssl s_client -ign_eof -connect localhost:58088 2>/dev/null | sed -n '$s/closed$//p'`
+  t.assert_equal "servername is empty", res.chomp
+  res = `echo "GET /servername" | openssl s_client -ign_eof -connect localhost:58088 -servername ngx.example.com 2>/dev/null | sed -n '$s/closed$//p'`
+  t.assert_equal "ngx.example.com", res.chomp
+end
+
 t.assert('ngx_mruby - issue_172', 'location /issue_172') do
   res = HttpRequest.new.get base + '/issue_172/index.html'
   expect_content = 'hello world'.upcase


### PR DESCRIPTION

When there is access from clients not compatible with SNI, mruby_script can be executed on IP basis