### PR TITLE
Improve ssl error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,6 @@ script:
   - echo "NGINX_SRC_PATCH=${NGINX_SRC_PATCH}" >> nginx_version
   - echo "NGINX_SRC_VER=nginx-${NGINX_SRC_MAJOR}.${NGINX_SRC_MINOR}.${NGINX_SRC_PATCH}" >> nginx_version
   - sh test.sh
+
+after_failure:
+  - cat build/nginx/logs/error.log

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -2040,6 +2040,7 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
   ngx_str_t host;
   mrb_int ai;
   mrb_state *mrb;
+  int rc;
 
   c = ngx_ssl_get_connection(ssl_conn);
   if (c == NULL) {
@@ -2150,10 +2151,14 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
     ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: changing certificate to cert=%V key=%V",
                   &mscf->cert_path, &mscf->cert_key_path);
-    ngx_http_mruby_set_der_certificate(ssl_conn, &mscf->cert_path, &mscf->cert_key_path);
+    rc = ngx_http_mruby_set_der_certificate(ssl_conn, &mscf->cert_path, &mscf->cert_key_path);
   } else {
     ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: changing certificate by mem buffer");
-    ngx_http_mruby_set_der_certificate_data(ssl_conn, &mscf->cert_data, &mscf->cert_key_data);
+    rc = ngx_http_mruby_set_der_certificate_data(ssl_conn, &mscf->cert_data, &mscf->cert_key_data);
+  }
+  if (rc != NGX_OK) {
+    ngx_log_error(NGX_LOG_ERR, c->log, 0, MODULE_NAME " : mruby ssl handler: failed to change certificate.\n");
+    return 0;
   }
 
   return 1;


### PR DESCRIPTION
* Don't ignore setting der_certificate failure.
* Cat error log on travis if build failed. It makes debug easier.