### PR TITLE
Simplify Makefile.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,7 +12,8 @@ RAKE=rake -j $(NUM_THREADS)
 
 NGX_MRUBY_ROOT=$(shell pwd)
 NGX_SRC_ROOT=@NGX_SRC_ROOT@
-NGX_CONFIG_OPT=@NGX_CONFIG_OPT@
+BUILD_DIR=@BUILD_DIR@
+
 ifeq ($(wildcard $(NGX_SRC_ROOT)/auto/configure),)
   NGX_CONFIGURE = ./configure
 else
@@ -23,39 +24,30 @@ endif
 MRUBY_ROOT=@MRUBY_ROOT@
 NDK_ROOT=@NDK_ROOT@
 
-#   suport mrbgems
-# libmruby.flags.mak contains MRUBY_* variables, but it is created when building mruby.
+# libmruby.flags.mak contains MRUBY_* variables. It is created while building mruby.
 MRUBY_MAK_FILE := $(MRUBY_ROOT)/build/host/lib/libmruby.flags.mak
 ifneq ($(wildcard $(MRUBY_MAK_FILE)),) 
 include $(MRUBY_MAK_FILE)
 endif
-MRUBY_LIBDIR = @MRUBY_LIBDIR@ # comes from configure
+MRUBY_LIBDIR=@MRUBY_LIBDIR@ # comes from configure
+MRUBY_BUILD_DEPEND_TARGETS=@MRUBY_BUILD_DEPEND_TARGETS@
+NGX_MRUBY_CFLAGS+=@NGX_MRUBY_CFLAGS@ # Use it in build_config.rb to build mruby
 
 NGX_OPENSSL_SRC=@NGX_OPENSSL_SRC@
 NGX_OPENSSL_OPT=@NGX_OPENSSL_OPT@
-ifdef NGX_OPENSSL_SRC
-  NGX_CONFIG_OPT := --with-openssl="$(NGX_OPENSSL_SRC)" $(NGX_CONFIG_OPT)
-endif
-
-ifdef NGX_OPENSSL_OPT
-  NGX_CONFIG_OPT := --with-openssl-opt="$(NGX_OPENSSL_OPT)" $(NGX_CONFIG_OPT)
-endif
+NGX_OPENSSL_INSTALL_DIR=@NGX_OPENSSL_INSTALL_DIR@
+NGX_CONFIG_OPT=@NGX_CONFIG_OPT@
+NGX_CFLAGS=@NGX_CFLAGS@
+NGX_LDFLAGS=@NGX_LDFLAGS@
+NGX_LIBS=@NGX_LIBS@
+NGX_CONFIG_ADD_MODULE_OPT_NAME=@NGX_CONFIG_ADD_MODULE_OPT_NAME@
+NGX_MAKEFILE_DEPENDS_TARGET=@NGX_MAKEFILE_DEPENDS_TARGET@
+BUILD_DYNAMIC_MODULE=@BUILD_DYNAMIC_MODULE@ # DON'T USE THIS. ONLY FOR COMPAT TARGETS
 
 #   flags
-CFLAGS = $(MRUBY_CFLAGS) -I/usr/local/include
-LDFLAGS = $(MRUBY_LDFLAGS) -L/usr/local/lib
-LIBS = $(MRUBY_LIBS) $(MRUBY_LDFLAGS_BEFORE_LIBS) -L$(MRUBY_LIBDIR) -lmruby
-
-build_mruby_targets=
-ifdef NGX_OPENSSL_SRC
-ifdef BUILD_DYNAMIC_MODULE
-  LDFLAGS := -L$(NGX_OPENSSL_SRC)/.openssl/lib -Wl,-rpath=$(NGX_OPENSSL_SRC)/.openssl/lib $(LDFLAGS)
-else
-  LIBS := $(NGX_OPENSSL_SRC)/.openssl/lib/libssl.a $(NGX_OPENSSL_SRC)/.openssl/lib/libcrypto.a $(LIBS)
-endif # BUILD_DYNAMIC_MODULE
-  CFLAGS := -I$(NGX_OPENSSL_SRC)/.openssl/include $(CFLAGS)
-  build_mruby_targets := openssl
-endif # NGX_OPENSSL_SRC
+CFLAGS = $(NGX_CFLAGS) $(MRUBY_CFLAGS) -I/usr/local/include
+LDFLAGS = $(NGX_LDFLAGS) $(MRUBY_LDFLAGS) -L/usr/local/lib
+LIBS = $(NGX_LIBS) $(MRUBY_LIBS) $(MRUBY_LDFLAGS_BEFORE_LIBS) -L$(MRUBY_LIBDIR) -lmruby
 
 #
 # targets
@@ -69,13 +61,13 @@ clean:
 	-rm -rf mrbgems_config mrbgems_config_dynamic
 
 clobber: clean_mruby clean
-	-rm -rf tmp autom4te.cache config config.status config.log build build_dynamic .openssl_build_done .openssl_configure_done
+	-rm -rf tmp autom4te.cache config config.status config.log $(BUILD_DIR) .openssl_build_done .openssl_configure_done
 
 #
 # mruby
 #
-build_mruby: $(build_mruby_targets)
-	cd $(MRUBY_ROOT) && $(RAKE) MRUBY_CONFIG=$(NGX_MRUBY_ROOT)/build_config.rb
+build_mruby: $(MRUBY_BUILD_DEPEND_TARGETS)
+	cd $(MRUBY_ROOT) && $(RAKE) MRUBY_CONFIG=$(NGX_MRUBY_ROOT)/build_config.rb NGX_MRUBY_CFLAGS="$(NGX_MRUBY_CFLAGS)"
 
 clean_mruby:
 	cd $(MRUBY_ROOT) && $(RAKE) deep_clean && rm -rf build
@@ -88,17 +80,11 @@ $(MRUBY_MAK_FILE): build_mruby
 build_ngx_mruby: build_mruby $(NGX_SRC_ROOT)/objs/Makefile
 	cd $(NGX_SRC_ROOT) && $(MAKE)
 
-ifdef BUILD_DYNAMIC_MODULE
-$(NGX_SRC_ROOT)/objs/Makefile: mrbgems_config_dynamic
+$(NGX_SRC_ROOT)/objs/Makefile: $(NGX_MAKEFILE_DEPENDS_TARGET)
 	cd $(NGX_SRC_ROOT) \
-	&& $(NGX_CONFIGURE) --add-dynamic-module=$(NGX_MRUBY_ROOT) --add-module=$(NDK_ROOT) $(NGX_CONFIG_OPT)
-else
-$(NGX_SRC_ROOT)/objs/Makefile: mrbgems_config
-	cd $(NGX_SRC_ROOT) \
-	&& $(NGX_CONFIGURE) --add-module=$(NGX_MRUBY_ROOT) --add-module=$(NDK_ROOT) $(NGX_CONFIG_OPT)
-endif
+	&& $(NGX_CONFIGURE) $(NGX_CONFIG_ADD_MODULE_OPT_NAME)=$(NGX_MRUBY_ROOT) --add-module=$(NDK_ROOT) $(NGX_CONFIG_OPT)
 
-# libmruby.flags.mak is generated, so invoke make to reevaluate MRUBY_* variables.
+# libmruby.flags.mak is generated or updated, so invoke make command to reevaluate MRUBY_* variables in it.
 mrbgems_config: $(MRUBY_MAK_FILE)
 	$(MAKE) generate_gems_config
 
@@ -121,7 +107,7 @@ make_ngx_mruby:
 
 ngx_mruby: 
 ifdef BUILD_DYNAMIC_MODULE
-	@echo "Error: Tried to build static linked nginx with BUILD_DYNAMIC_MODULE" && false
+	@echo "Error: You must rerun configure without --enable-dynamic" && false
 else
 	$(MAKE) build_ngx_mruby
 	@echo "Warning: ngx_mruby target will be removed. Use build_ngx_mruby without BUILD_DYNAMIC_MODULE instead."
@@ -132,7 +118,7 @@ ifdef BUILD_DYNAMIC_MODULE
 	$(MAKE) build_ngx_mruby
 	@echo "Warning: ngx_mruby_dynamic target will be removed. Use build_ngx_mruby with BUILD_DYNAMIC_MODULE instead."
 else
-	@echo "Error: Tried to build dynamic linked nginx without BUILD_DYNAMIC_MODULE" && false
+	@echo "Error: You must rerun configure with --enable-dynamic" && false
 endif
 
 #
@@ -148,7 +134,7 @@ openssl: .openssl_build_done
 .openssl_configure_done:
 	(cd $(NGX_OPENSSL_SRC) \
 	&& if [ -f Makefile ]; then $(MAKE) clean; fi \
-	&& ./config --prefix=$(NGX_OPENSSL_SRC)/.openssl --shared zlib -fPIC enable-tlsext $(NGX_OPENSSL_OPT) \
+	&& ./config --prefix=$(NGX_OPENSSL_INSTALL_DIR) --shared zlib -fPIC enable-tlsext $(NGX_OPENSSL_OPT) \
 	&& $(MAKE) depend) \
 	&& cp /dev/null .openssl_configure_done
 

--- a/build.sh
+++ b/build.sh
@@ -27,9 +27,11 @@ fi
 if [ -n "$BUILD_DYNAMIC_MODULE" ]; then
     BUILD_DIR='build_dynamic'
     NGINX_INSTALL_DIR=`pwd`'/build_dynamic/nginx'
+    CONFIG_OPT="--enable-dynamic-module --with-build-dir=$BUILD_DIR"
 else
     BUILD_DIR='build'
     NGINX_INSTALL_DIR=`pwd`'/build/nginx'
+    CONFIG_OPT="--with-build-dir=$BUILD_DIR"
 fi
 
 if [ "$NGINX_CONFIG_OPT_ENV" != "" ]; then
@@ -80,7 +82,7 @@ if [ -d "./mruby/${BUILD_DIR}" ]; then
 fi
 
 echo "ngx_mruby configure ..."
-./configure --with-ngx-src-root=${NGINX_SRC} --with-ngx-config-opt="${NGINX_CONFIG_OPT}" $@
+./configure ${CONFIG_OPT} --with-ngx-src-root=${NGINX_SRC} --with-ngx-config-opt="${NGINX_CONFIG_OPT}" $@
 echo "ngx_mruby configure ... Done"
 
 echo "ngx_mruby building ..."

--- a/build_config.rb
+++ b/build_config.rb
@@ -5,7 +5,6 @@ MRuby::Build.new('host') do |conf|
   conf.gembox 'full-core'
 
   conf.cc do |cc|
-    cc.flags << '-fPIC' if ENV['BUILD_DYNAMIC_MODULE']
     cc.flags << ENV['NGX_MRUBY_CFLAGS'] if ENV['NGX_MRUBY_CFLAGS']
   end
 

--- a/configure
+++ b/configure
@@ -625,6 +625,16 @@ MRUBY_INCDIR
 MRUBY_ROOT
 NGX_CONFIG_OPT
 NGX_OPENSSL_OPT
+NGX_LIBS
+NGX_LDFLAGS
+NGX_CFLAGS
+NGX_OPENSSL_INSTALL_DIR
+NGX_MRUBY_CFLAGS
+BUILD_DYNAMIC_MODULE
+NGX_CONFIG_ADD_MODULE_OPT_NAME
+NGX_MAKEFILE_DEPENDS_TARGET
+BUILD_DIR
+MRUBY_BUILD_DEPEND_TARGETS
 NGX_OPENSSL_SRC
 NGX_SRC_ROOT
 LIBOBJS
@@ -658,7 +668,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -683,6 +692,8 @@ ac_user_opts='
 enable_option_checking
 with_ngx_src_root
 with_openssl_src
+with_build_dir
+enable_dynamic_module
 with_openssl_opt
 with_ngx_config_opt
 with_mruby_root
@@ -737,7 +748,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -990,15 +1000,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1136,7 +1137,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1289,7 +1290,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1313,11 +1313,18 @@ if test -n "$ac_init_help"; then
 
   cat <<\_ACEOF
 
+Optional Features:
+  --disable-option-checking  ignore unrecognized --enable/--with options
+  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
+  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-dynamic-module Use nginx dynamic modules
+
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-ngx-src-root=DIR pathname to ngx_src_root [[ngx_src_root]]
   --with-openssl-src=DIR  set path to OpenSSL library sources
+  --with-build-dir=DIR    set build directory path
   --with-openssl-opt=OPTIONS
                           set additional build options for OpenSSL
   --with-ngx-config-opt=OPT
@@ -3660,6 +3667,54 @@ if test "${with_openssl_src+set}" = set; then :
   withval=$with_openssl_src; NGX_OPENSSL_SRC="$with_openssl_src"
 fi
 
+if test "X$NGX_OPENSSL_SRC" != X ; then
+    MRUBY_BUILD_DEPEND_TARGETS=openssl
+fi
+
+
+
+BUILD_DIR=build
+
+# Check whether --with-build_dir was given.
+if test "${with_build_dir+set}" = set; then :
+  withval=$with_build_dir; BUILD_DIR="$with_build_dir"
+fi
+
+
+
+# Check whether --enable-dynamic_module was given.
+if test "${enable_dynamic_module+set}" = set; then :
+  enableval=$enable_dynamic_module;
+fi
+
+if test "x$enable_dynamic_module" = xyes ; then
+  NGX_MAKEFILE_DEPENDS_TARGET=mrbgems_config_dynamic
+  NGX_CONFIG_ADD_MODULE_OPT_NAME=--add-dynamic-module
+  BUILD_DYNAMIC_MODULE=TRUE
+  NGX_MRUBY_CFLAGS=-fPIC
+else
+  NGX_MAKEFILE_DEPENDS_TARGET=mrbgems_config
+  NGX_CONFIG_ADD_MODULE_OPT_NAME=--add-module
+  BUILD_DYNAMIC_MODULE=""
+  NGX_MRUBY_CFLAGS=""
+fi
+
+
+
+
+
+if test "X$NGX_OPENSSL_SRC" != X ; then
+  NGX_OPENSSL_INSTALL_DIR=$NGX_OPENSSL_SRC/.openssl
+  NGX_CFLAGS=-I$NGX_OPENSSL_INSTALL_DIR/include
+  if test "x$enable_dynamic_module" = xyes ; then
+      NGX_LDFLAGS="-L$NGX_OPENSSL_INSTALL_DIR/lib\ -Wl,-rpath=$NGX_OPENSSL_INSTALL_DIR/lib"
+  else
+      NGX_LIBS="$NGX_OPENSSL_INSTALL_DIR/lib/libssl.a $NGX_OPENSSL_INSTALL_DIR/lib/libcrypto.a"
+  fi
+fi
+
+
+
 
 
 NGX_OPENSSL_OPT=
@@ -3671,7 +3726,6 @@ fi
 
 
 
-# nginx src root
 NGX_CONFIG_OPT=
 
 # Check whether --with-ngx_config_opt was given.
@@ -3679,9 +3733,12 @@ if test "${with_ngx_config_opt+set}" = set; then :
   withval=$with_ngx_config_opt; NGX_CONFIG_OPT="$with_ngx_config_opt"
 fi
 
-#if test "$NGX_CONFIG_OPT" = no; then
-#    AC_MSG_ERROR([nginx configure option not found.])
-#fi
+if test "X$NGX_OPENSSL_SRC" != X ; then
+    NGX_CONFIG_OPT="$NGX_CONFIG_OPT --with-openssl=$NGX_OPENSSL_SRC"
+fi
+if test "X$NGX_OPENSSL_OPT" != X ; then
+    NGX_CONFIG_OPT="$NGX_CONFIG_OPT --with-openssl-opt=$NGX_OPENSSL_OPT"
+fi
 
 
 # mruby root
@@ -3723,22 +3780,6 @@ if test "${with_ndk_root+set}" = set; then :
 fi
 
 
-
-## support mrbgems
-#ENABLE_GEMS=false
-#AC_ARG_ENABLE([mrbgems],
-#    [AS_HELP_STRING([--enable-mrbgems],
-#        [mrbgems feature (default is no)])],
-#    [],
-#    [enable_mrbgems=no]
-#)
-#
-#AS_IF([test "x$enable_mrbgems" != xno],
-#    [AC_DEFINE([ENABLE_GEMS], [1], [mrbgems support])
-#        ENABLE_GEMS=true
-#    ]
-#)
-#AC_SUBST(ENABLE_GEMS)
 
 ac_config_files="$ac_config_files Makefile config"
 

--- a/configure.in
+++ b/configure.in
@@ -38,7 +38,49 @@ NGX_OPENSSL_SRC=
 AC_ARG_WITH(openssl_src, AC_HELP_STRING([--with-openssl-src=DIR],
     [set path to OpenSSL library sources]),
     [NGX_OPENSSL_SRC="$with_openssl_src"])
+if test "X$NGX_OPENSSL_SRC" != X ; then
+    MRUBY_BUILD_DEPEND_TARGETS=openssl  
+fi
 AC_SUBST(NGX_OPENSSL_SRC)
+AC_SUBST(MRUBY_BUILD_DEPEND_TARGETS)
+
+BUILD_DIR=build
+AC_ARG_WITH(build_dir, AC_HELP_STRING([--with-build-dir=DIR],
+    [set build directory path]),
+    [BUILD_DIR="$with_build_dir"])
+AC_SUBST(BUILD_DIR)
+
+AC_ARG_ENABLE(dynamic_module, AC_HELP_STRING([--enable-dynamic-module],
+    [Use nginx dynamic modules]))
+if test "x$enable_dynamic_module" = xyes ; then
+  NGX_MAKEFILE_DEPENDS_TARGET=mrbgems_config_dynamic
+  NGX_CONFIG_ADD_MODULE_OPT_NAME=--add-dynamic-module
+  BUILD_DYNAMIC_MODULE=TRUE
+  NGX_MRUBY_CFLAGS=-fPIC
+else
+  NGX_MAKEFILE_DEPENDS_TARGET=mrbgems_config
+  NGX_CONFIG_ADD_MODULE_OPT_NAME=--add-module
+  BUILD_DYNAMIC_MODULE=""
+  NGX_MRUBY_CFLAGS=""
+fi
+AC_SUBST(NGX_MAKEFILE_DEPENDS_TARGET)
+AC_SUBST(NGX_CONFIG_ADD_MODULE_OPT_NAME)
+AC_SUBST(BUILD_DYNAMIC_MODULE)
+AC_SUBST(NGX_MRUBY_CFLAGS)
+
+if test "X$NGX_OPENSSL_SRC" != X ; then
+  NGX_OPENSSL_INSTALL_DIR=$NGX_OPENSSL_SRC/.openssl
+  NGX_CFLAGS=-I$NGX_OPENSSL_INSTALL_DIR/include
+  if test "x$enable_dynamic_module" = xyes ; then
+      NGX_LDFLAGS="-L$NGX_OPENSSL_INSTALL_DIR/lib\ -Wl,-rpath=$NGX_OPENSSL_INSTALL_DIR/lib"
+  else
+      NGX_LIBS="$NGX_OPENSSL_INSTALL_DIR/lib/libssl.a $NGX_OPENSSL_INSTALL_DIR/lib/libcrypto.a"
+  fi
+fi
+AC_SUBST(NGX_OPENSSL_INSTALL_DIR)
+AC_SUBST(NGX_CFLAGS)
+AC_SUBST(NGX_LDFLAGS)
+AC_SUBST(NGX_LIBS)
 
 NGX_OPENSSL_OPT=
 AC_ARG_WITH(openssl_opt, AC_HELP_STRING([--with-openssl-opt=OPTIONS],
@@ -46,14 +88,16 @@ AC_ARG_WITH(openssl_opt, AC_HELP_STRING([--with-openssl-opt=OPTIONS],
     [NGX_OPENSSL_OPT="$with_openssl_opt"])
 AC_SUBST(NGX_OPENSSL_OPT)
 
-# nginx src root
 NGX_CONFIG_OPT=
 AC_ARG_WITH(ngx_config_opt, AC_HELP_STRING([--with-ngx-config-opt=OPT],
     [ngxin configure option [[ngx_config_opt]]]),
     [NGX_CONFIG_OPT="$with_ngx_config_opt"])
-#if test "$NGX_CONFIG_OPT" = no; then
-#    AC_MSG_ERROR([nginx configure option not found.])
-#fi
+if test "X$NGX_OPENSSL_SRC" != X ; then
+    NGX_CONFIG_OPT="$NGX_CONFIG_OPT --with-openssl=$NGX_OPENSSL_SRC"
+fi
+if test "X$NGX_OPENSSL_OPT" != X ; then
+    NGX_CONFIG_OPT="$NGX_CONFIG_OPT --with-openssl-opt=$NGX_OPENSSL_OPT"
+fi
 AC_SUBST(NGX_CONFIG_OPT)
 
 # mruby root
@@ -83,22 +127,6 @@ AC_ARG_WITH(ndk_root, AC_HELP_STRING([--with-ndk-root=DIR],
     [pathname to ndk_root [[ndk_root]]]),
     [NDK_ROOT="$with_ndk_root"])
 AC_SUBST(NDK_ROOT)
-
-## support mrbgems
-#ENABLE_GEMS=false
-#AC_ARG_ENABLE([mrbgems],
-#    [AS_HELP_STRING([--enable-mrbgems],
-#        [mrbgems feature (default is no)])], 
-#    [],
-#    [enable_mrbgems=no] 
-#)
-#
-#AS_IF([test "x$enable_mrbgems" != xno],
-#    [AC_DEFINE([ENABLE_GEMS], [1], [mrbgems support])
-#        ENABLE_GEMS=true
-#    ]
-#)
-#AC_SUBST(ENABLE_GEMS)
 
 AC_CONFIG_FILES([Makefile config])
 AC_OUTPUT

--- a/test.sh
+++ b/test.sh
@@ -27,10 +27,13 @@ fi
 if [ -n "$BUILD_DYNAMIC_MODULE" ]; then
     BUILD_DIR='build_dynamic'
     NGINX_INSTALL_DIR=`pwd`'/build_dynamic/nginx'
+    CONFIG_OPT="--enable-dynamic-module --with-build-dir=$BUILD_DIR"
 else
     BUILD_DIR='build'
     NGINX_INSTALL_DIR=`pwd`'/build/nginx'
+    CONFIG_OPT="--with-build-dir=$BUILD_DIR"
 fi
+export NGINX_INSTALL_DIR # for test/t/ngx_mruby.rb
 
 if [ $NGINX_SRC_MINOR -ge 11 -a $NGINX_SRC_PATCH -ge 5 ]; then
     NGINX_CONFIG_OPT="--prefix=${NGINX_INSTALL_DIR} ${NGINX_DEFUALT_OPT} --with-stream"
@@ -75,7 +78,7 @@ if [ "$ONLY_BUILD_NGX_MRUBY" = "" ]; then
   cd ..
 
   echo "ngx_mruby configure ..."
-  ./configure --with-ngx-src-root=${NGINX_SRC} --with-ngx-config-opt="${NGINX_CONFIG_OPT}" $@
+  ./configure ${CONFIG_OPT} --with-ngx-src-root=${NGINX_SRC} --with-ngx-config-opt="${NGINX_CONFIG_OPT}" $@
   echo "ngx_mruby configure ... Done"
 fi
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -455,10 +455,9 @@ t.assert('ngx_mruby - ssl certificate changing using data instead of file') do
   t.assert_equal "", res
 end
 
-dir = ENV['BUILD_DYNAMIC_MODULE'] == 'TRUE' ? 'build_dynamic' : 'build'
-fname = File.expand_path("../../../#{dir}/nginx/html/set_ssl_cert_and_key.rb", __FILE__)
-
 t.assert('ngx_mruby - ssl certificate changing - reading handler from file without caching') do
+  fname = File.join(ENV['NGINX_INSTALL_DIR'], 'html/set_ssl_cert_and_key.rb')
+
   res = `curl -k #{base_ssl(58085) + '/'}`
   t.assert_equal 'ssl test ok', res
 
@@ -478,6 +477,8 @@ t.assert('ngx_mruby - ssl certificate changing - reading handler from file witho
 end
 
 t.assert('ngx_mruby - ssl certificate changing - reading handler from file with caching') do
+  fname = File.join(ENV['NGINX_INSTALL_DIR'], 'html/set_ssl_cert_and_key.rb')
+
   res = `curl -k #{base_ssl(58086) + '/'}`
   t.assert_equal 'ssl test ok', res
 
@@ -496,10 +497,9 @@ t.assert('ngx_mruby - ssl certificate changing - reading handler from file with 
   t.assert_equal "", `#{cmd_h}`.chomp
 end
 
-dir = ENV['BUILD_DYNAMIC_MODULE'] == 'TRUE' ? 'build_dynamic' : 'build'
 t.assert('ngx_mruby - Nginx::SSL.errlogger') do
   `openssl s_client -servername localhost -connect localhost:58087 < /dev/null 2>/dev/null`
-  error_log = File.read File.expand_path("../../../#{dir}/nginx/logs/error.log", __FILE__)
+  error_log = File.read File.join(ENV['NGINX_INSTALL_DIR'], 'logs/error.log');
   t.assert_true error_log.include? 'Servername is localhost while SSL handshaking'
 end
 


### PR DESCRIPTION
Get rid of a few environment variable in Makefile. build.sh and test.sh still respect them.

* NGX_OPENSSL_SRC and NGX_OPENSSL_OPT are retired from Makefile.
* BUILD_DYNAMIC_MODULE is almost gone from Makefile. Instead add --enable-dynamic-module support to configure.
* build_config.rb and test/t/ngx_mruby.rb don't use BUILD_DYNAMIC_MODULE anymore.
* Add --with-build-dir support to configure.