### PR TITLE
exception stack trace log support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ script:
   - sh test.sh
 
 after_failure:
-  - cat build/nginx/logs/error.log
+  - if [ -e build/nginx/logs/error.log ]; then cat build/nginx/logs/error.log ; else cat build_dynamic/nginx/logs/error.log; fi

--- a/src/http/ngx_http_mruby_core.h
+++ b/src/http/ngx_http_mruby_core.h
@@ -34,6 +34,7 @@ typedef struct ngx_http_mruby_ctx_t {
 } ngx_http_mruby_ctx_t;
 
 void ngx_mrb_raise_error(mrb_state *mrb, mrb_value obj, ngx_http_request_t *r);
+void ngx_mrb_raise_connection_error(mrb_state *mrb, mrb_value exc, ngx_connection_t *c);
 void ngx_mrb_raise_cycle_error(mrb_state *mrb, mrb_value obj, ngx_cycle_t *cycle);
 void ngx_mrb_raise_conf_error(mrb_state *mrb, mrb_value obj, ngx_conf_t *cf);
 

--- a/test.sh
+++ b/test.sh
@@ -105,6 +105,17 @@ fi
 cp -pr test/html/* ${NGINX_INSTALL_DIR}/html/.
 sed -e "s|__NGXDOCROOT__|${NGINX_INSTALL_DIR}/html/|g" test/html/set_ssl_cert_and_key.rb > ${NGINX_INSTALL_DIR}/html/set_ssl_cert_and_key.rb
 
+if [ -e ${NGINX_INSTALL_DIR}/logs/error.log ]; then
+    touch ${NGINX_INSTALL_DIR}/logs/error.log.bak 
+    cat ${NGINX_INSTALL_DIR}/logs/error.log >> ${NGINX_INSTALL_DIR}/logs/error.log.bak
+    cp /dev/null ${NGINX_INSTALL_DIR}/logs/error.log
+fi
+if [ -e ${NGINX_INSTALL_DIR}/logs/access.log ]; then
+    touch ${NGINX_INSTALL_DIR}/logs/access.log.bak 
+    cat ${NGINX_INSTALL_DIR}/logs/access.log >> ${NGINX_INSTALL_DIR}/logs/access.log.bak
+    cp /dev/null ${NGINX_INSTALL_DIR}/logs/access.log
+fi
+
 echo "====================================="
 echo ""
 echo "ngx_mruby starting and logging"

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -764,6 +764,9 @@ http {
             Nginx.rputs Userdata.new.req_body
           ';
         }
+        location /backtrace {
+          mruby_content_handler build/nginx/html/backtrace.rb;
+        }
     }
 
     server {

--- a/test/html/backtrace.rb
+++ b/test/html/backtrace.rb
@@ -1,0 +1,14 @@
+class Foo
+  def foo
+    b = Bar.new
+    b.bar
+  end
+end
+
+class Bar
+  def bar
+    raise "Intentional Error for testing ngx_mrb_log_backtrace"
+  end
+end
+
+Foo.new.foo

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -564,7 +564,7 @@ t.assert('ngx_mruby - backtrace log', 'location /backtrace') do
 
   fname = File.join(ENV['NGINX_INSTALL_DIR'], 'logs/error.log')
   found = 0
-  File.open(fname) {|f| f.each_line {|line| found += 1 if line.index('build/nginx/html/backtrace.rb:') } }
+  File.open(fname) {|f| f.each_line {|line| found += 1 if line.index('/nginx/html/backtrace.rb:') } }
   t.assert_equal 4, found
 end
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -558,6 +558,16 @@ t.assert('ngx_mruby - BUG: request_body issue 268', 'location /issue-268') do
   t.assert_equal %({\"hello\": \"ngx_mruby\"}\n), res
 end
 
+t.assert('ngx_mruby - backtrace log', 'location /backtrace') do
+  res = HttpRequest.new.get base + '/backtrace'
+  t.assert_equal 500, res["code"]
+
+  fname = File.join(ENV['NGINX_INSTALL_DIR'], 'logs/error.log')
+  found = 0
+  File.open(fname) {|f| f.each_line {|line| found += 1 if line.index('build/nginx/html/backtrace.rb:') } }
+  t.assert_equal 4, found
+end
+
 #
 # nginx stream test verison 1.9.6 later
 #


### PR DESCRIPTION
If you build ngx_mruby with NGX_DEBUG, you will get exception stack trace as below.

```
2017/05/16 03:58:05 [error] 5032#0: *114 mrb_run failed: return 500 HTTP status code to client: error: build/nginx/html/backtrace.
rb:10: Intentional Error for testing ngx_mrb_log_backtrace (RuntimeError), client: 127.0.0.1, server: localhost, request: "GET /ba
cktrace HTTP/1.0", host: "127.0.0.1"
2017/05/16 03:58:05 [error] 5032#0: *114 build/nginx/html/backtrace.rb:10:in Bar.bar, client: 127.0.0.1, server: localhost, reques
t: "GET /backtrace HTTP/1.0", host: "127.0.0.1"
2017/05/16 03:58:05 [error] 5032#0: *114 build/nginx/html/backtrace.rb:4:in Foo.foo, client: 127.0.0.1, server: localhost, request
: "GET /backtrace HTTP/1.0", host: "127.0.0.1"
2017/05/16 03:58:05 [error] 5032#0: *114 build/nginx/html/backtrace.rb:14, client: 127.0.0.1, server: localhost, request: "GET /ba
cktrace HTTP/1.0", host: "127.0.0.1"
```