### PR TITLE
ngx_mrb_log_backtrace only defined using NGX_DEBUG

### DIFF
--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -25,6 +25,7 @@
 
 ngx_module_t ngx_http_mruby_module;
 
+#if (NGX_DEBUG)
 static void ngx_mrb_log_backtrace(mrb_state *mrb, mrb_value obj, ngx_log_t *log)
 {
   if (mrb_type(obj) == MRB_TT_EXCEPTION) {
@@ -41,6 +42,7 @@ static void ngx_mrb_log_backtrace(mrb_state *mrb, mrb_value obj, ngx_log_t *log)
     }
   }
 }
+#endif
 
 void ngx_mrb_raise_error(mrb_state *mrb, mrb_value exc, ngx_http_request_t *r)
 {


### PR DESCRIPTION
ref: #292 