### PR TITLE
Support stream listener method on server context

### DIFF
--- a/src/stream/ngx_stream_mruby_core.c
+++ b/src/stream/ngx_stream_mruby_core.c
@@ -94,8 +94,10 @@ static mrb_value ngx_stream_mrb_add_listener(mrb_state *mrb, mrb_value self)
 
   ls->socklen = u.socklen;
   ls->backlog = NGX_LISTEN_BACKLOG;
+#if (nginx_version >= 1013002)
   ls->rcvbuf = -1;
   ls->sndbuf = -1;
+#endif
   ls->type = SOCK_STREAM;
   ls->wildcard = u.wildcard;
   ls->ctx = cf->ctx;

--- a/src/stream/ngx_stream_mruby_core.c
+++ b/src/stream/ngx_stream_mruby_core.c
@@ -94,7 +94,7 @@ static mrb_value ngx_stream_mrb_add_listener(mrb_state *mrb, mrb_value self)
 
   ls->socklen = u.socklen;
   ls->backlog = NGX_LISTEN_BACKLOG;
-#if (nginx_version >= 1013002)
+#if (nginx_version >= 1013000)
   ls->rcvbuf = -1;
   ls->sndbuf = -1;
 #endif

--- a/src/stream/ngx_stream_mruby_core.c
+++ b/src/stream/ngx_stream_mruby_core.c
@@ -21,6 +21,7 @@
 #include "mruby/proc.h"
 #include "mruby/string.h"
 #include "mruby/variable.h"
+#include "mruby/hash.h"
 
 static mrb_value ngx_stream_mrb_errlogger(mrb_state *mrb, mrb_value self)
 {
@@ -50,6 +51,99 @@ static mrb_value ngx_stream_mrb_get_ngx_mruby_name(mrb_state *mrb, mrb_value sel
   return mrb_str_new_lit(mrb, MODULE_NAME);
 }
 
+static mrb_value ngx_stream_mrb_add_listener(mrb_state *mrb, mrb_value self)
+{
+  ngx_stream_core_main_conf_t *cmcf;
+  ngx_stream_mruby_srv_conf_t *mscf = mrb->ud;
+  ngx_stream_core_srv_conf_t *cscf = mscf->ctx->cscf;
+  ngx_conf_t *cf = mscf->ctx->cf;
+  mrb_value listener, address;
+  ngx_str_t addr;
+  ngx_url_t u;
+  ngx_uint_t i;
+  ngx_stream_listen_t *ls, *als;
+
+  mrb_get_args(mrb, "H", &listener);
+  address = mrb_hash_get(mrb, listener, mrb_check_intern_cstr(mrb, "address"));
+  addr.data = (u_char *)RSTRING_PTR(address);
+  addr.len = RSTRING_LEN(address);
+
+  ngx_memzero(&u, sizeof(ngx_url_t));
+
+  u.url = addr;
+  u.listen = 1;
+  cscf->listen = 1;
+
+  if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
+    if (u.err) {
+      ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "%s in \"%V\" of the \"listen\" directive via mruby", u.err, &u.url);
+    }
+
+    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_stream_mrb_add_listener ngx_parse_url failed");
+  }
+
+  cmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_core_module);
+
+  ls = ngx_array_push(&cmcf->listen);
+  if (ls == NULL) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_stream_mrb_add_listener ngx_array_push failed");
+  }
+
+  ngx_memzero(ls, sizeof(ngx_stream_listen_t));
+  ngx_memcpy(&ls->sockaddr.sockaddr, &u.sockaddr, u.socklen);
+
+  ls->socklen = u.socklen;
+  ls->backlog = NGX_LISTEN_BACKLOG;
+  ls->rcvbuf = -1;
+  ls->sndbuf = -1;
+  ls->type = SOCK_STREAM;
+  ls->wildcard = u.wildcard;
+  ls->ctx = cf->ctx;
+
+#if (NGX_HAVE_INET6)
+  ls->ipv6only = 1;
+#endif
+
+#if !(NGX_WIN32)
+  if (mrb_bool(mrb_hash_get(mrb, listener, mrb_check_intern_cstr(mrb, "udp")))) {
+    ls->type = SOCK_DGRAM;
+  }
+#endif
+
+  if (ls->type == SOCK_DGRAM) {
+#if (NGX_STREAM_SSL)
+    if (ls->ssl) {
+      mrb_raise(mrb, E_RUNTIME_ERROR, "\"ssl\" parameter is incompatible with \"udp\"");
+    }
+#endif
+
+    if (ls->so_keepalive) {
+      mrb_raise(mrb, E_RUNTIME_ERROR, "\"so_keepalive\" parameter is incompatible with \"udp\"");
+    }
+
+    if (ls->proxy_protocol) {
+      mrb_raise(mrb, E_RUNTIME_ERROR, "\"proxy_protocol\" parameter is incompatible with \"udp\"");
+    }
+  }
+
+  als = cmcf->listen.elts;
+
+  for (i = 0; i < cmcf->listen.nelts - 1; i++) {
+    if (ls->type != als[i].type) {
+      continue;
+    }
+
+    if (ngx_cmp_sockaddr(&als[i].sockaddr.sockaddr, als[i].socklen, &ls->sockaddr.sockaddr, ls->socklen, 1) != NGX_OK) {
+      continue;
+    }
+
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "duplicate \"%V\" address and port pair", &u.url);
+    mrb_raise(mrb, E_RUNTIME_ERROR, "duplicate address and port pair");
+  }
+
+  return mrb_true_value();
+}
+
 void ngx_stream_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
 {
   mrb_define_const(mrb, class, "OK", mrb_fixnum_value(NGX_OK));
@@ -73,4 +167,5 @@ void ngx_stream_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_class_method(mrb, class, "errlogger", ngx_stream_mrb_errlogger, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, class, "log", ngx_stream_mrb_errlogger, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, class, "module_name", ngx_stream_mrb_get_ngx_mruby_name, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class, "add_listener", ngx_stream_mrb_add_listener, MRB_ARGS_REQ(1));
 }

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -94,7 +94,7 @@ static ngx_command_t ngx_stream_mruby_commands[] = {
     {ngx_string("mruby_stream_code"), NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
      ngx_stream_mruby_build_code, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
 
-    {ngx_string("mruby_server_context_code"), NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
+    {ngx_string("mruby_stream_server_context_code"), NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
      ngx_stream_mruby_server_context_code, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
 
     ngx_null_command};

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -588,6 +588,7 @@ static char *ngx_stream_mruby_server_context_code(ngx_conf_t *cf, ngx_command_t 
   ngx_mrb_code_t *code;
   ngx_int_t rc;
   mrb_int ai;
+  void *tmp_ud;
 
   mscf->ctx->cf = cf;
   mscf->ctx->cscf = ngx_stream_conf_get_module_srv_conf(cf, ngx_stream_core_module);
@@ -608,8 +609,10 @@ static char *ngx_stream_mruby_server_context_code(ngx_conf_t *cf, ngx_command_t 
 
   ai = mrb_gc_arena_save(mrb);
 
+  tmp_ud = mrb->ud;
   mrb->ud = mscf;
   mrb_run(mrb, code->proc, mrb_top_self(mrb));
+  mrb->ud = tmp_ud;
 
   if (mrb->exc) {
     ngx_stream_mruby_raise_conf_error(mrb, mrb_obj_value(mrb->exc), cf);

--- a/src/stream/ngx_stream_mruby_module.h
+++ b/src/stream/ngx_stream_mruby_module.h
@@ -10,6 +10,8 @@
 #include <nginx.h>
 #include <ngx_core.h>
 #include <ngx_stream.h>
+#include "mruby.h"
+#include "mruby/compile.h"
 
 #define MODULE_NAME "ngx_mruby-stream-module"
 
@@ -19,5 +21,39 @@ typedef struct {
   ngx_stream_session_t *s;
   ngx_int_t stream_status;
 } ngx_stream_mruby_internal_ctx_t;
+
+typedef enum code_type_t { NGX_MRB_CODE_TYPE_FILE, NGX_MRB_CODE_TYPE_STRING } code_type_t;
+
+typedef struct ngx_mrb_code_t {
+  union code {
+    char *file;
+    char *string;
+  } code;
+  code_type_t code_type;
+  struct RProc *proc;
+  mrbc_context *ctx;
+} ngx_mrb_code_t;
+
+typedef struct {
+  mrb_state *mrb;
+  ngx_conf_t *cf;
+  ngx_stream_core_srv_conf_t *cscf;
+} ngx_stream_mruby_conf_ctx_t;
+
+typedef struct {
+
+  ngx_stream_mruby_conf_ctx_t *ctx;
+  ngx_mrb_code_t *init_code;
+  ngx_mrb_code_t *init_worker_code;
+  ngx_mrb_code_t *exit_worker_code;
+
+} ngx_stream_mruby_main_conf_t;
+
+typedef struct {
+
+  ngx_stream_mruby_conf_ctx_t *ctx;
+  ngx_mrb_code_t *code;
+
+} ngx_stream_mruby_srv_conf_t;
 
 #endif // NGX_STREAM_MRUBY_MODULE_H

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -35,7 +35,7 @@ stream {
 
   # test for add listener
   server {
-      mruby_server_context_code '
+      mruby_stream_server_context_code '
         Nginx::Stream.add_listener({address: "127.0.0.1:12350"})
         Nginx::Stream.add_listener({address: "12351"})
       ';

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -39,7 +39,7 @@ stream {
         Nginx::Stream.add_listener({address: "127.0.0.1:12350"})
         Nginx::Stream.add_listener({address: "12351"})
       ';
-      proxy_pass dynamic_server0;
+      proxy_pass static_server0;
   }
 
   # test for dynamic tcp load balancer

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -33,6 +33,15 @@ stream {
       proxy_pass dynamic_server0;
   }
 
+  # test for add listener
+  server {
+      mruby_server_context_code '
+        Nginx::Stream.add_listener({address: "127.0.0.1:12350"})
+        Nginx::Stream.add_listener({address: "12351"})
+      ';
+      proxy_pass dynamic_server0;
+  }
+
   # test for dynamic tcp load balancer
   # upstream changed from 127.0.0.1:58081 to 127.0.0.1:58080 in mruby
   server {

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -615,6 +615,12 @@ if nginx_features.is_stream_supported?
     res = HttpRequest.new.get(base4 + '/mruby')
     t.assert_equal 'Hello ngx_mruby world!', res["body"]
   end
+  t.assert('ngx_mruby - add linstener', '127.0.0.1:12350 to 127.0.0.1:58080') do
+    res = HttpRequest.new.get('http://127.0.0.1:12350' + '/mruby')
+    t.assert_equal 'Hello ngx_mruby world!', res["body"]
+    res = HttpRequest.new.get('http://127.0.0.1:12351' + '/mruby')
+    t.assert_equal 'Hello ngx_mruby world!', res["body"]
+  end
 end
 
 t.report


### PR DESCRIPTION
```nginx
  server {
      mruby_stream_server_context_code '
        Nginx::Stream.add_listener({address: "127.0.0.1:12350"})
        Nginx::Stream.add_listener({address: "12351"})
      ';
      proxy_pass static_server0;
  }
```