### PR TITLE
fix deadlink in document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,11 @@
 ※ [hello world simple benchmark, see details of blog entry.](http://blog.matsumoto-r.jp/?p=3974)
 
 ## Documents
-- [Install](https://github.com/matsumotory/ngx_mruby/docs/install)
-- [Test](https://github.com/matsumotory/ngx_mruby/docs/test)
-- [Directives](https://github.com/matsumotory/ngx_mruby/docs/directives)
-- [Class and Method](https://github.com/matsumotory/ngx_mruby/docs/class_and_method)
-- [Use Case](https://github.com/matsumotory/ngx_mruby/docs/use_case)
+- [Install](./install)
+- [Test](./test)
+- [Directives](./directives)
+- [Class and Method](./class_and_method)
+- [Use Case](./use_case)
 
 ## What's ngx_mruby
 __ngx_mruby is A Fast and Memory-Efficient Web Server Extension Mechanism Using Scripting Language mruby for nginx.__


### PR DESCRIPTION
ドキュメントのリンク先がデッドリンクになっていたので修正しました。
ドキュメントの体裁の修正のためチェックリストは削除しています。