### PR TITLE
[WIP] Enable to run mruby code within fiber and add async sleep

### DIFF
--- a/config.in
+++ b/config.in
@@ -25,6 +25,7 @@ NGX_MRUBY_SRCS="$ngx_addon_dir/src/http/ngx_http_mruby_module.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_filter.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_upstream.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_ssl.c \
+                $ngx_addon_dir/src/http/ngx_http_mruby_async.c \
                 "
 
 if [ $STREAM = YES ]; then

--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -823,6 +823,15 @@ http {
 }
 ```
 
+## Nginx::Async Class
+### Method
+#### Nginx::Async#sleep
+Do non-blocking sleep. Currenly it supports only rewrite and access phases.
+```ruby
+# sleep 3000 millisec
+Nginx::Async.sleep 3000
+```
+
 ## Nginx::Stream class
 - example
 

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -48,4 +48,16 @@ module Kernel
   def get_server_class
     Nginx
   end
+
+  def _ngx_mruby_prepare_fiber(app_proc)
+    fiber = Fiber.new do
+      app_proc.call
+    end
+
+    Proc.new do
+      rv = fiber.resume
+      is_alive = fiber.alive?
+      [is_alive, rv]
+    end
+  end
 end

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -1,0 +1,144 @@
+/*
+// ngx_http_mruby_async.c - ngx_mruby mruby module
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#include "ngx_http_mruby_async.h"
+#include "ngx_http_mruby_core.h"
+#include "ngx_http_mruby_request.h"
+
+#include <nginx.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+#include <mruby/array.h>
+#include <mruby/opcode.h>
+#include <mruby/proc.h>
+
+typedef struct {
+  mrb_state *mrb;
+  mrb_value *fiber;
+  ngx_http_request_t *r;
+} ngx_mrb_reentrant_t;
+
+mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RProc *rproc, mrb_value *result)
+{
+  mrb_value proc;
+  mrb_irep *irep;
+  mrb_value *fiber;
+
+  proc = mrb_obj_value(mrb_closure_new(mrb, rproc->body.irep));
+
+  // A part of them refer to https://github.com/h2o/h2o
+  // Replace OP_STOP with OP_RETURN to avoid stop VM
+  irep = rproc->body.irep;
+  irep->iseq[irep->ilen - 1] = MKOP_AB(OP_RETURN, irep->nlocals, OP_R_NORMAL);
+
+  fiber = (mrb_value *)ngx_palloc(r->pool, sizeof(mrb_value));
+  *fiber = mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_ngx_mruby_prepare_fiber", 1, proc);
+
+  return ngx_mrb_run_fiber(mrb, fiber, result);
+}
+
+mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
+{
+  mrb_value resume_results = mrb_nil_value();
+  mrb_value is_alive = mrb_false_value();
+
+  mrb->ud = fiber;
+
+  // TODO support passing arguments.
+  resume_results = mrb_funcall(mrb, *fiber, "call", 0, NULL);
+
+  is_alive = mrb_ary_entry(resume_results, 0);
+  if (result != NULL) {
+    *result = mrb_ary_entry(resume_results, 1);
+  }
+
+  if (mrb_test(is_alive)) {
+    mrb_gc_register(mrb, *fiber);
+  } else {
+    mrb_gc_unregister(mrb, *fiber);
+  }
+
+  return is_alive;
+}
+
+static void ngx_mrb_timer_handler(ngx_event_t *ev)
+{
+  ngx_mrb_reentrant_t *re;
+  ngx_http_mruby_ctx_t *ctx;
+  ngx_int_t rc = NGX_OK;
+
+  re = ev->data;
+
+  if (re->fiber != NULL) {
+    ngx_mrb_push_request(re->r);
+    if (!mrb_test(ngx_mrb_run_fiber(re->mrb, re->fiber, NULL))) {
+      re->fiber = NULL;
+    }
+    if (re->mrb->exc) {
+      ngx_mrb_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->r);
+      rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+  }
+
+  ctx = ngx_http_get_module_ctx(re->r, ngx_http_mruby_module);
+  if (ctx != NULL) {
+    if (rc != NGX_OK) {
+      re->r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+    rc = ngx_mrb_finalize_rputs(re->r, ctx);
+  } else {
+    rc = NGX_ERROR;
+  }
+
+  // progress to a next handler or finalize
+  if (rc == NGX_OK) {
+    re->r->phase_handler++;
+    ngx_http_core_run_phases(re->r);
+  } else {
+    ngx_http_finalize_request(re->r, rc);
+  }
+}
+
+static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
+{
+  unsigned int timer;
+  u_char *p;
+  ngx_event_t *ev;
+  ngx_mrb_reentrant_t *re;
+  ngx_http_request_t *r;
+
+  mrb_get_args(mrb, "i", &timer);
+
+  mrb_fiber_yield(mrb, 0, NULL);
+
+  r = ngx_mrb_get_request();
+
+  p = ngx_palloc(r->pool, sizeof(ngx_event_t) + sizeof(ngx_mrb_reentrant_t));
+
+  re = (ngx_mrb_reentrant_t *)(p + sizeof(ngx_event_t));
+  re->mrb = mrb;
+  re->fiber = (mrb_value *)mrb->ud;
+  re->r = r;
+
+  ev = (ngx_event_t *)p;
+  ngx_memzero(ev, sizeof(ngx_event_t));
+  ev->handler = ngx_mrb_timer_handler;
+  ev->data = re;
+  ev->log = ngx_cycle->log;
+
+  ngx_add_timer(ev, (ngx_msec_t)timer);
+
+  return self;
+}
+
+void ngx_mrb_async_class_init(mrb_state *mrb, struct RClass *class)
+{
+  struct RClass *class_async;
+
+  class_async = mrb_define_class_under(mrb, class, "Async", mrb->object_class);
+  mrb_define_class_method(mrb, class_async, "sleep", ngx_mrb_async_sleep, MRB_ARGS_REQ(1));
+}

--- a/src/http/ngx_http_mruby_async.h
+++ b/src/http/ngx_http_mruby_async.h
@@ -1,0 +1,16 @@
+/*
+// ngx_http_mruby_async.h - ngx_mruby mruby module header
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#ifndef NGX_HTTP_MRUBY_ASYNC_H
+#define NGX_HTTP_MRUBY_ASYNC_H
+
+#include <ngx_http.h>
+#include <mruby.h>
+
+mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RProc *proc, mrb_value *result);
+mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result);
+
+#endif // NGX_HTTP_MRUBY_ASYNC_H

--- a/src/http/ngx_http_mruby_async.h
+++ b/src/http/ngx_http_mruby_async.h
@@ -10,6 +10,7 @@
 #include <ngx_http.h>
 #include <mruby.h>
 
+void ngx_mrb_run_without_stop(mrb_state *mrb, struct RProc *rproc, mrb_value *result);
 mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RProc *proc, mrb_value *result);
 mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result);
 

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -94,7 +94,7 @@ void ngx_mrb_raise_conf_error(mrb_state *mrb, mrb_value exc, ngx_conf_t *cf)
 // TODO: Support rputs by multi directive
 ngx_int_t ngx_mrb_finalize_rputs(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ctx)
 {
-  ngx_int_t rc;
+  ngx_int_t rc = NGX_OK;
   ngx_mrb_rputs_chain_list_t *chain;
 
   chain = ctx->rputs_chain;
@@ -107,8 +107,7 @@ ngx_int_t ngx_mrb_finalize_rputs(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ct
     } else {
       rc = NGX_OK;
     }
-  }
-  if (r->headers_out.status == NGX_HTTP_OK || !(*chain->last)->buf->last_buf) {
+  } else if (r->headers_out.status == NGX_HTTP_OK || !(*chain->last)->buf->last_buf) {
     r->headers_out.status = NGX_HTTP_OK;
     (*chain->last)->buf->last_buf = 1;
     ngx_http_send_header(r);

--- a/src/http/ngx_http_mruby_core.h
+++ b/src/http/ngx_http_mruby_core.h
@@ -37,4 +37,6 @@ void ngx_mrb_raise_connection_error(mrb_state *mrb, mrb_value exc, ngx_connectio
 void ngx_mrb_raise_cycle_error(mrb_state *mrb, mrb_value obj, ngx_cycle_t *cycle);
 void ngx_mrb_raise_conf_error(mrb_state *mrb, mrb_value obj, ngx_conf_t *cf);
 
+ngx_int_t ngx_mrb_finalize_rputs(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ctx);
+
 #endif // NGX_HTTP_MRUBY_CORE_H

--- a/src/http/ngx_http_mruby_init.c
+++ b/src/http/ngx_http_mruby_init.c
@@ -29,6 +29,9 @@ void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *calss);
 #if (NGX_HTTP_SSL)
 void ngx_mrb_ssl_class_init(mrb_state *mrb, struct RClass *class);
 #endif
+#ifdef NGX_USE_MRUBY_ASYNC
+void ngx_mrb_async_class_init(mrb_state *mrb, struct RClass *calss);
+#endif
 
 ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
 {
@@ -54,6 +57,10 @@ ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
 #endif
 #if (NGX_HTTP_SSL)
   ngx_mrb_ssl_class_init(mrb, class);
+  GC_ARENA_RESTORE;
+#endif
+#ifdef NGX_USE_MRUBY_ASYNC
+  ngx_mrb_async_class_init(mrb, class);
   GC_ARENA_RESTORE;
 #endif
 

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -730,7 +730,11 @@ ngx_int_t ngx_mrb_run_cycle(ngx_cycle_t *cycle, ngx_mrb_state_t *state, ngx_mrb_
 {
   int ai = mrb_gc_arena_save(state->mrb);
   ngx_log_error(NGX_LOG_INFO, cycle->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
+#ifdef NGX_USE_MRUBY_ASYNC
+  ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
+#else
   mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
+#endif
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
     ngx_mrb_raise_cycle_error(state->mrb, mrb_obj_value(state->mrb->exc), cycle);
@@ -746,7 +750,12 @@ ngx_int_t ngx_mrb_run_conf(ngx_conf_t *cf, ngx_mrb_state_t *state, ngx_mrb_code_
 {
   int ai = mrb_gc_arena_save(state->mrb);
   ngx_log_error(NGX_LOG_INFO, cf->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
+#ifdef NGX_USE_MRUBY_ASYNC
+  ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
+#else
   mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
+#endif
+  NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
     ngx_mrb_raise_conf_error(state->mrb, mrb_obj_value(state->mrb->exc), cf);
@@ -2135,10 +2144,18 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
         return 1;
       }
     }
+#ifdef NGX_USE_MRUBY_ASYNC
+    ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_code->proc, NULL);
+#else
     mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
+#endif
   }
   if (mscf->ssl_handshake_inline_code != NGX_CONF_UNSET_PTR) {
+#ifdef NGX_USE_MRUBY_ASYNC
+    ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_inline_code->proc, NULL);
+#else
     mrb_run(mrb, mscf->ssl_handshake_inline_code->proc, mrb_top_self(mrb));
+#endif
   }
 
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(mrb, mscf->ssl_handshake_code);

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -26,6 +26,8 @@
 #define NGX_USE_MRUBY_UPSTREAM
 #endif
 
+#define NGX_USE_MRUBY_ASYNC
+
 typedef enum code_type_t { NGX_MRB_CODE_TYPE_FILE, NGX_MRB_CODE_TYPE_STRING } code_type_t;
 
 typedef struct ngx_mrb_state_t {

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -786,6 +786,13 @@ http {
         location /backtrace {
           mruby_content_handler build/nginx/html/backtrace.rb;
         }
+
+        location /async_sleep {
+            mruby_rewrite_handler_code '
+              Nginx::Async.sleep 1000
+              Nginx.return Nginx::HTTP_OK
+            ';
+        }
     }
 
     server {

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -790,6 +790,7 @@ http {
         location /async_sleep {
             mruby_rewrite_handler_code '
               Nginx::Async.sleep 1000
+              Nginx.rputs "body"
               Nginx.return Nginx::HTTP_OK
             ';
         }

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -39,7 +39,8 @@ class NginxFeatures
     @minor >= 10 || (@minor == 9 && @patch >= 6)
   end
   def is_async_supported?
-    Nginx.const_defined?("Async")
+    # Should we enable Nginx::Async as default?
+    true
   end
 end
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -38,6 +38,9 @@ class NginxFeatures
     # 1.9.6 or later
     @minor >= 10 || (@minor == 9 && @patch >= 6)
   end
+  def is_async_supported?
+    Nginx.const_defined?("Async")
+  end
 end
 
 t = SimpleTest.new "ngx_mruby test"
@@ -622,5 +625,13 @@ if nginx_features.is_stream_supported?
     t.assert_equal 'Hello ngx_mruby world!', res["body"]
   end
 end
+
+if nginx_features.is_async_supported?
+  t.assert('ngx_mruby - Nginx.Async.sleep', 'location /async_sleep') do
+    res = HttpRequest.new.get base + '/async_sleep'
+    t.assert_equal 200, res.code
+  end
+end
+
 
 t.report


### PR DESCRIPTION
## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).


## Summary

Enable to run mruby code with in proc wraps fiber. And this PR add supporting `Nginx::Async#sleep`, non-blocking sleep method by using fiber and timer event.

## Concerns

* Wrapping with fiber will cause overhead at non yield mruby code. Should does this feature disable as default?