### PR TITLE
Use mrb_int to avoid possible buffer overflows.

### DIFF
--- a/src/http/ngx_http_mruby_upstream.c
+++ b/src/http/ngx_http_mruby_upstream.c
@@ -91,7 +91,7 @@ static mrb_value ngx_mrb_upstream_init(mrb_state *mrb, mrb_value self)
 
 static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
 {
-  unsigned int cache;
+  mrb_int cache;
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
   __ngx_http_upstream_keepalive_srv_conf_t *kcf;
 

--- a/src/http/ngx_http_mruby_var.c
+++ b/src/http/ngx_http_mruby_var.c
@@ -115,7 +115,8 @@ ARENA_RESTOR_AND_ERROR:
 static mrb_value ngx_mrb_var_method_missing(mrb_state *mrb, mrb_value self)
 {
   mrb_value name, *a;
-  int alen, c_len;
+  mrb_int alen;
+  int c_len;
   mrb_value s_name;
   char *c_name;
   ngx_http_request_t *r;


### PR DESCRIPTION
mrb_get_args() with format specifier "i" and "*" requires mrb_int. It is now 64 bit on 64 bit systems.
Using 32 bit int might cause buffer overflows with the latest mruby.
See https://github.com/mruby/mruby/commit/f0f4a1088a270e339407a24ffe8be748f4764fc2
I found it by inspection, so I don't know if it actually happens.

## Pull-Request Check List

- [x] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
