### PR TITLE
[WIP] Add mruby_ssl_client_hello_handler

### DIFF
--- a/docs/directives/README.md
+++ b/docs/directives/README.md
@@ -79,6 +79,8 @@ http | mruby_init_worker /path/to/code.rb  |init worker process phase|__[http co
 http | mruby_init_worker_code inline-code |init worker process phase|__[http conf]__ write inline Ruby code in ngxin.conf 
 http | mruby_exit_worker /path/to/code.rb  |exit worker process phase|__[http conf]__ write file path in ngxin.conf 
 http | mruby_exit_worker_code inline-code |exit worker process phase|__[http conf]__ write inline Ruby code in ngxin.conf 
+server | mruby_ssl_client_hello_handler /path/to/code.rb  |ssl handshake phase|__[server conf]__ write file path in ngxin.conf 
+server | mruby_ssl_client_hello_handler_code inline-code |ssl handshake phase|__[server conf]__ write inline Ruby code in ngxin.conf 
 server | mruby_ssl_handshake_handler /path/to/code.rb  |ssl handshake phase|__[server conf]__ write file path in ngxin.conf 
 server | mruby_ssl_handshake_handler_code inline-code |ssl handshake phase|__[server conf]__ write inline Ruby code in ngxin.conf 
 server, location | mruby_add_handler|create location configuration phase|__[location conf]__  

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -83,8 +83,10 @@ static char *ngx_http_mruby_exit_worker_inline(ngx_conf_t *cf, ngx_command_t *cm
 #if (NGX_HTTP_SSL)
 static char *ngx_http_mruby_ssl_handshake_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_mruby_ssl_handshake_inline(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
 static char *ngx_http_mruby_ssl_client_hello_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_mruby_ssl_client_hello_inline(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+#endif
 #endif /* NGX_HTTP_SSL */
 static char *ngx_http_mruby_server_config_inline(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
@@ -1164,6 +1166,7 @@ static char *ngx_http_mruby_ssl_handshake_inline(ngx_conf_t *cf, ngx_command_t *
   return ngx_http_mruby_initialize_inline_code(cf, mmcf->state, &mscf->ssl_handshake_inline_code, __func__);
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
 static char *ngx_http_mruby_ssl_client_hello_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
     ngx_http_mruby_srv_conf_t *mscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_mruby_module);
@@ -1186,6 +1189,7 @@ static char *ngx_http_mruby_ssl_client_hello_inline(ngx_conf_t *cf, ngx_command_
     mscf->state = mmcf->state;
     return ngx_http_mruby_initialize_inline_code(cf, mmcf->state, &mscf->ssl_client_hello_inline_code, __func__);
 }
+#endif
 #endif /* NGX_HTTP_SSL */
 
 static char *ngx_http_mruby_init_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -447,8 +447,7 @@ static char *ngx_http_mruby_merge_srv_conf(ngx_conf_t *cf, void *parent, void *c
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
     SSL_CTX_set_client_hello_cb(sscf->ssl.ctx, (SSL_client_hello_cb_fn)ngx_http_mruby_ssl_client_hello_handler, NULL);
 #else
-    ngx_log_error(NGX_LOG_EMERG, cf->log, 0, MODULE_NAME " : OpenSSL 1.1.1dev or later required but found " OPENSSL_VERSION_TEXT);
-    return NGX_CONF_ERROR;
+    ngx_log_error(NGX_LOG_INFO, cf->log, 0, MODULE_NAME " : mruby_ssl_client_hello_handler require OpenSSL 1.1.1dev or later but found " OPENSSL_VERSION_TEXT);
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x1000205fL
     SSL_CTX_set_cert_cb(sscf->ssl.ctx, ngx_http_mruby_ssl_cert_handler, NULL);

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -178,10 +178,12 @@ static ngx_command_t ngx_http_mruby_commands[] = {
 
     {ngx_string("mruby_ssl_handshake_handler_code"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
      ngx_http_mruby_ssl_handshake_inline, NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
     {ngx_string("mruby_ssl_client_hello_handler"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE12,
      ngx_http_mruby_ssl_client_hello_phase, NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
     {ngx_string("mruby_ssl_client_hello_handler_code"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
      ngx_http_mruby_ssl_client_hello_inline, NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
+#endif
 
 #endif /* NGX_HTTP_SSL */
 

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -59,6 +59,8 @@ extern ngx_module_t ngx_http_mruby_module;
 
 typedef struct {
   ngx_mrb_state_t *state;
+  ngx_mrb_code_t *ssl_client_hello_code;
+  ngx_mrb_code_t *ssl_client_hello_inline_code;
   ngx_mrb_code_t *ssl_handshake_code;
   ngx_mrb_code_t *ssl_handshake_inline_code;
   ngx_mrb_code_t *server_config_inline_code;
@@ -69,8 +71,10 @@ typedef struct {
   ngx_str_t cert_key_path;
   ngx_str_t cert_data;
   ngx_str_t cert_key_data;
-#if (NGX_HTTP_SSL) && OPENSSL_VERSION_NUMBER >= 0x1000205fL
+#if (NGX_HTTP_SSL)
+#if OPENSSL_VERSION_NUMBER >= 0x1000205fL
   ngx_connection_t *connection;
+#endif
 #endif
 } ngx_http_mruby_srv_conf_t;
 


### PR DESCRIPTION
## Pull-Request Check List

- [x] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).

# description


in openssl 1.1.1dev (almost same `master`) ,  it provides handler when it accepts client hello message. 
the PR add `mruby_ssl_client_hello_handler` and `mruby_ssl_client_hello_handler_code` directive 
in order to use the `client_hello_cb` hook in ngx_mruby.

# why the PR is WIP

when using openssl 1.1.0 or later, ngx_mruby buildsystem can not find libssh and libcrypto.
it seems that there are a lot changing openssl `config` script. (e.g. removing `enable-tlsext` option).
even if I add test, we can not run test in CI.
To run test for the PR in ci, we need to fix them before adding test.


