### PR TITLE
Avoid odd number exception / `Nginx.Request#args_to_hash (mrblib)`

### DIFF
--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -29,7 +29,7 @@ class Nginx
     private
 
     def args_to_hash(args)
-      Hash[*args.split("&").map{|arg| arg.split("=")}.flatten]
+      Hash[*args.split("&").map{|arg| arg.split("=", 2)}.flatten]
     end
   end
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -702,7 +702,7 @@ http {
         location /get_uri_args {
           mruby_content_handler_code '
             args = Nginx::Request.new.uri_args
-            Nginx.echo args.map{|k, v| "#{k}:#{v}" }.join(\n)
+            Nginx.echo args.map{|k, v| "#{k}:#{v}" }.join("\n")
           ';
         }
         location /set_uri_args {

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -437,6 +437,11 @@ t.assert('ngx_mruby - get uri_args', 'location /get_uri_args') do
   t.assert_equal "k:v\n", res["body"]
 end
 
+t.assert('ngx_mruby - get uri_args includes empty value', 'location /get_uri_args') do
+  res = HttpRequest.new.get base + '/get_uri_args/?k1=v1&k2=&k3=v3'
+  t.assert_equal "k1:v1\nk2:\nk3:v3\n", res["body"]
+end
+
 t.assert('ngx_mruby - set uri_args', 'location /set_uri_args') do
   res = HttpRequest.new.get base + '/set_uri_args'
   t.assert_equal "pass=ngx_mruby\n", res['body']


### PR DESCRIPTION
## before

When interpreting the parameters which value side was empty, it had been caused an exception.

```
> args_to_hash("a=1&b=2&c=&d=4")
ArgumentError: odd number of arguments for Hash
```

## after

this pull request changes that empty value parse it as an empty string.

```
> args_to_hash("a=1&b=2&c=&d=4")
=> {"a"=>"1", "b"=>"2", "c"=>"", "d"=>"4"}
```


## Pull-Request Check List

- [ ] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).