### PR TITLE
Remove iij/mruby-io, iij/mruby-pack, and iij/mruby-socket.

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -20,13 +20,10 @@ MRuby::Build.new('host') do |conf|
   #
   # Recommended for ngx_mruby
   #
-  conf.gem :github => 'iij/mruby-io'
   conf.gem :github => 'iij/mruby-env'
   conf.gem :github => 'iij/mruby-dir'
   conf.gem :github => 'iij/mruby-digest'
   conf.gem :github => 'iij/mruby-process'
-  conf.gem :github => 'iij/mruby-pack'
-  conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'mattn/mruby-json'
   conf.gem :github => 'mattn/mruby-onig-regexp'
   conf.gem :github => 'matsumotory/mruby-redis'
@@ -82,8 +79,6 @@ MRuby::Build.new('test') do |conf|
   conf.gem :github => 'matsumotory/mruby-simpletest'
   conf.gem :github => 'mattn/mruby-http'
   conf.gem :github => 'mattn/mruby-json'
-  conf.gem :github => 'iij/mruby-io'
-  conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'iij/mruby-pack'
   conf.gem :github => 'iij/mruby-env'
 


### PR DESCRIPTION
They are part of mruby distribution now. See ngx_mruby/mruby/mrbgems.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
