### PR TITLE
Fix memory leak.

### DIFF
--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -375,12 +375,13 @@ static ngx_int_t ngx_stream_mruby_shared_state_compile(ngx_conf_t *cf, mrb_state
     if ((mrb_file = fopen((char *)code->code.file, "r")) == NULL) {
       return NGX_ERROR;
     }
-
+    NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(mrb, code);
     code->ctx = mrbc_context_new(mrb);
     mrbc_filename(mrb, code->ctx, (char *)code->code.file);
     p = mrb_parse_file(mrb, mrb_file, code->ctx);
     fclose(mrb_file);
   } else {
+    NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(mrb, code);
     code->ctx = mrbc_context_new(mrb);
     mrbc_filename(mrb, code->ctx, "INLINE CODE");
     p = mrb_parse_string(mrb, (char *)code->code.string, code->ctx);
@@ -602,6 +603,7 @@ static char *ngx_stream_mruby_server_context_code(ngx_conf_t *cf, ngx_command_t 
   }
 
   rc = ngx_stream_mruby_shared_state_compile(cf, mrb, code);
+  NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(mrb, code);
 
   if (rc != NGX_OK) {
     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);


### PR DESCRIPTION
## Pull-Request Check List

- [x] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).

This change fixes the following memory leak.

```
==25107== 84 (72 direct, 12 indirect) bytes in 1 blocks are definitely lost in loss record 72 of 142
==25107==    at 0x4C29BFD: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==25107==    by 0x4C2BACB: realloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==25107==    by 0x56A206: mrb_default_allocf (state.c:55)
==25107==    by 0x56ABEE: mrb_realloc_simple (gc.c:206)
==25107==    by 0x56AC70: mrb_realloc (gc.c:220)
==25107==    by 0x56AD45: mrb_malloc (gc.c:242)
==25107==    by 0x56ADC6: mrb_calloc (gc.c:260)
==25107==    by 0x5B0C77: mrbc_context_new (parse.y:5678)
==25107==    by 0x55BE38: ngx_stream_mruby_shared_state_compile (ngx_stream_mruby_module.c:384)
==25107==    by 0x55C6A6: ngx_stream_mruby_server_context_code (ngx_stream_mruby_module.c:604)
==25107==    by 0x47A40B: ngx_conf_handler (ngx_conf_file.c:463)
==25107==    by 0x479F5F: ngx_conf_parse (ngx_conf_file.c:319)
```
