### PR TITLE
Update docs: Add certificate_data= and certificate_key_data=

### DIFF
--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -219,6 +219,33 @@ mruby_ssl_handshake_handler_code '
   ssl.certificate_key = "/path/to/#{ssl.servername}.key"
 ';
 ```
+#### Nginx::SSL#certificate_data=
+
+set certificate data (String) for a request
+
+```nginx
+mruby_ssl_handshake_handler_code '
+  ssl = Nginx::SSL.new
+  certificate_data = File.read("/path/to/#{ssl.servername}.crt")
+  key_data = File.read("/path/to/#{ssl.servername}.key")
+  ssl.certificate_data = certificate_data
+  ssl.certificate_key_data = key_data
+';
+```
+
+#### Nginx::SSL#certificate_key_data=
+
+set certificate key data (String) for a request
+
+```nginx
+mruby_ssl_handshake_handler_code '
+  ssl = Nginx::SSL.new
+  certificate_data = File.read("/path/to/#{ssl.servername}.crt")
+  key_data = File.read("/path/to/#{ssl.servername}.key")
+  ssl.certificate_data = certificate_data
+  ssl.certificate_key_data = key_data
+';
+```
 
 #### Nginx::SSL.errlogger
 ```ruby


### PR DESCRIPTION
## Pull-Request Check List

- [x] Add patches into `src/`.
  - No changes
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
  - No changes, no tests
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).

----

ngx_mruby has `Nginx::SSL#certificate_data=` and `Nginx::SSL#certificate_key_data=` methods but not documented.