### PR TITLE
Run all request processing handler on fiber and support simple async methods

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -20,13 +20,10 @@ MRuby::Build.new('host') do |conf|
   #
   # Recommended for ngx_mruby
   #
-  conf.gem :github => 'iij/mruby-io'
   conf.gem :github => 'iij/mruby-env'
   conf.gem :github => 'iij/mruby-dir'
   conf.gem :github => 'iij/mruby-digest'
   conf.gem :github => 'iij/mruby-process'
-  conf.gem :github => 'iij/mruby-pack'
-  conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'mattn/mruby-json'
   conf.gem :github => 'mattn/mruby-onig-regexp'
   conf.gem :github => 'matsumotory/mruby-redis'
@@ -82,8 +79,6 @@ MRuby::Build.new('test') do |conf|
   conf.gem :github => 'matsumotory/mruby-simpletest'
   conf.gem :github => 'mattn/mruby-http'
   conf.gem :github => 'mattn/mruby-json'
-  conf.gem :github => 'iij/mruby-io'
-  conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'iij/mruby-pack'
   conf.gem :github => 'iij/mruby-env'
 

--- a/config.in
+++ b/config.in
@@ -25,6 +25,7 @@ NGX_MRUBY_SRCS="$ngx_addon_dir/src/http/ngx_http_mruby_module.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_filter.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_upstream.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_ssl.c \
+                $ngx_addon_dir/src/http/ngx_http_mruby_async.c \
                 "
 
 if [ $STREAM = YES ]; then

--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -11,6 +11,7 @@
 - [Nginx::Headers_out Class](#nginxheaders_out-class)
 - [Nginx::Filter Class](#nginxfilter-class)
 - [Nginx::Upstream Class](#nginxupstream-class)
+- [Nginx::Async class](#nginxasync-class)
 - [Process Class](https://github.com/iij/mruby-process)
 - [IO Class](https://github.com/iij/mruby-io)
 - [Array Class for pack](https://github.com/iij/mruby-pack)
@@ -41,6 +42,20 @@
 Server = get_server_class
 
 Server.echo "hello world"
+```
+
+#### return
+
+ngx_mruby v2 supports `return` method.
+
+```ruby
+location /enable_return {
+    mruby_content_handler_code '
+         Nginx.rputs"hoge"
+         return if true 
+         Nginx.rputs "foo" #=> do not response
+    ';
+}
 ```
 
 #### server_name

--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -825,6 +825,15 @@ http {
 }
 ```
 
+## Nginx::Async Class
+### Method
+#### Nginx::Async#sleep
+Do non-blocking sleep. Currenly it supports only rewrite and access phases.
+```ruby
+# sleep 3000 millisec
+Nginx::Async.sleep 3000
+```
+
 ## Nginx::Stream class
 - example
 

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -48,4 +48,16 @@ module Kernel
   def get_server_class
     Nginx
   end
+
+  def _ngx_mruby_prepare_fiber(app_proc)
+    fiber = Fiber.new do
+      app_proc.call
+    end
+
+    Proc.new do
+      rv = fiber.resume
+      is_alive = fiber.alive?
+      [is_alive, rv]
+    end
+  end
 end

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -49,15 +49,14 @@ module Kernel
     Nginx
   end
 
-  def _ngx_mruby_prepare_fiber(app_proc)
-    fiber = Fiber.new do
-      app_proc.call
-    end
-
+  def _ngx_mrb_prepare_fiber(nginx_handler)
     Proc.new do
-      rv = fiber.resume
-      is_alive = fiber.alive?
-      [is_alive, rv]
+      fiber_handler = Fiber.new do
+        nginx_handler.call
+      end
+
+      # BUG?: return nginx_handler directly from fiber, not proc.
+      fiber_handler.resume
     end
   end
 end

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -50,11 +50,10 @@ module Kernel
   end
 
   def _ngx_mrb_prepare_fiber(nginx_handler)
+    fiber_handler = Fiber.new do
+      nginx_handler.call
+    end
     Proc.new do
-      fiber_handler = Fiber.new do
-        nginx_handler.call
-      end
-
       # BUG?: return nginx_handler directly from fiber, not proc.
       result = fiber_handler.resume
       [fiber_handler.alive?, result]

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -54,7 +54,7 @@ module Kernel
       nginx_handler.call
     end
     Proc.new do
-      # BUG?: return nginx_handler directly from fiber, not proc.
+      # BUG?: return nginx_handler directly from fiber, not proc in any case.
       result = fiber_handler.resume
       [fiber_handler.alive?, result]
     end

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -50,10 +50,9 @@ module Kernel
   end
 
   def _ngx_mrb_prepare_fiber(nginx_handler)
-    fiber_handler = Fiber.new do
-      nginx_handler.call
-    end
-    Proc.new do
+    fiber_handler = Fiber.new { nginx_handler.call }
+
+    lambda do
       # BUG?: return nginx_handler directly from fiber, not proc in any case.
       result = fiber_handler.resume
       [fiber_handler.alive?, result]

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -56,7 +56,8 @@ module Kernel
       end
 
       # BUG?: return nginx_handler directly from fiber, not proc.
-      fiber_handler.resume
+      result = fiber_handler.resume
+      [fiber_handler.alive?, result]
     end
   end
 end

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -101,14 +101,14 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
   if (re->fiber != NULL) {
     ngx_mrb_push_request(re->r);
 
-    if (!mrb_test(ngx_mrb_resume_fiber(re->mrb, re->fiber))) {
-      // can not resume the fiber, the fiber was finished
-      mrb_gc_unregister(re->mrb, *re->fiber);
-      re->fiber = NULL;
-    } else {
+    if (mrb_test(ngx_mrb_resume_fiber(re->mrb, re->fiber))) {
       ngx_http_core_run_phases(re->r);
       ngx_http_run_posted_requests(re->r->connection);
       return;
+    } else {
+      // can not resume the fiber, the fiber was finished
+      mrb_gc_unregister(re->mrb, *re->fiber);
+      re->fiber = NULL;
     }
 
     ngx_http_run_posted_requests(re->r->connection);

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -125,6 +125,17 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
   }
 }
 
+static void
+ngx_mrb_async_sleep_cleanup(void *data)
+{
+  ngx_event_t *ev = (ngx_event_t *)data;
+
+  if (ev->timer_set) {
+    ngx_del_timer(ev);
+    return;
+  }
+}
+
 static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
 {
   unsigned int timer;
@@ -132,6 +143,7 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   ngx_event_t *ev;
   ngx_mrb_reentrant_t *re;
   ngx_http_request_t *r;
+  ngx_http_cleanup_t *cln;
 
   mrb_get_args(mrb, "i", &timer);
 
@@ -153,6 +165,14 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   ev->log = ngx_cycle->log;
 
   ngx_add_timer(ev, (ngx_msec_t)timer);
+
+  cln = ngx_http_cleanup_add(r, 0);
+  if (cln == NULL) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_http_cleanup_add failed");
+  }
+
+  cln->handler = ngx_mrb_async_sleep_cleanup;
+  cln->data = ev;
 
   return self;
 }

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -17,6 +17,8 @@
 #include <mruby/proc.h>
 #include <mruby/error.h>
 
+#define ngx_mrb_resume_fiber(mrb, fiber) ngx_mrb_run_fiber(mrb, fiber, NULL)
+
 typedef struct {
   mrb_state *mrb;
   mrb_value *fiber;
@@ -87,8 +89,6 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
 
   return aliving;
 }
-
-#define ngx_mrb_resume_fiber(mrb, fiber) ngx_mrb_run_fiber(mrb, fiber, NULL)
 
 static void ngx_mrb_timer_handler(ngx_event_t *ev)
 {

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -150,6 +150,8 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "i", &timer);
 
+  // suspend the Ruby handler on Nginx::Async.sleep
+  // resume the Ruby handler on ngx_mrb_resume_fiber() on ngx_mrb_timer_handler()
   mrb_fiber_yield(mrb, 0, NULL);
 
   r = ngx_mrb_get_request();

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -15,6 +15,7 @@
 #include <mruby/array.h>
 #include <mruby/opcode.h>
 #include <mruby/proc.h>
+#include <mruby/error.h>
 
 typedef struct {
   mrb_state *mrb;
@@ -22,10 +23,19 @@ typedef struct {
   ngx_http_request_t *r;
 } ngx_mrb_reentrant_t;
 
+static void replace_stop(mrb_irep *irep)
+{
+  // A part of them refer to https://github.com/h2o/h2o
+  // Replace OP_STOP with OP_RETURN to avoid stop VM
+  irep->iseq[irep->ilen - 1] = MKOP_AB(OP_RETURN, irep->nlocals, OP_R_NORMAL);
+}
+
 void ngx_mrb_run_without_stop(mrb_state *mrb, struct RProc *rproc, mrb_value *result)
 {
   mrb_value mrb_result;
-  mrb_value proc = mrb_obj_value(mrb_proc_new(mrb, rproc->body.irep));
+  mrb_value proc;
+
+  proc = mrb_obj_value(mrb_proc_new(mrb, rproc->body.irep));
 
   mrb_result = mrb_funcall(mrb, proc, "call", 0, NULL);
   if (result != NULL) {
@@ -35,39 +45,31 @@ void ngx_mrb_run_without_stop(mrb_state *mrb, struct RProc *rproc, mrb_value *re
 
 mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RProc *rproc, mrb_value *result)
 {
-  mrb_value proc;
-  mrb_value *fiber;
+  mrb_value proc, fiber;
 
-  proc = mrb_obj_value(mrb_closure_new(mrb, rproc->body.irep));
+  replace_stop(rproc->body.irep);
+  proc = mrb_obj_value(mrb_proc_new(mrb, rproc->body.irep));
+  fiber = mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_ngx_mrb_prepare_fiber", 1, proc);
 
-  fiber = (mrb_value *)ngx_palloc(r->pool, sizeof(mrb_value));
-  *fiber = mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_ngx_mruby_prepare_fiber", 1, proc);
-
-  return ngx_mrb_run_fiber(mrb, fiber, result);
+  return ngx_mrb_run_fiber(mrb, &fiber, result);
 }
 
 mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
 {
-  mrb_value resume_results = mrb_nil_value();
-  mrb_value is_alive = mrb_false_value();
+  mrb_value resume_result = mrb_nil_value();
 
   mrb->ud = fiber;
 
-  // TODO support passing arguments.
-  resume_results = mrb_funcall(mrb, *fiber, "call", 0, NULL);
-
-  is_alive = mrb_ary_entry(resume_results, 0);
-  if (result != NULL) {
-    *result = mrb_ary_entry(resume_results, 1);
+  resume_result = mrb_funcall(mrb, *fiber, "call", 0, NULL);
+  if (mrb->exc) {
+    return mrb_false_value();
   }
 
-  if (mrb_test(is_alive)) {
-    mrb_gc_register(mrb, *fiber);
-  } else {
-    mrb_gc_unregister(mrb, *fiber);
-  }
+  *result = resume_result;
 
-  return is_alive;
+  mrb_gc_protect(mrb, *fiber);
+
+  return mrb_false_value();
 }
 
 static void ngx_mrb_timer_handler(ngx_event_t *ev)

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -22,20 +22,12 @@ typedef struct {
   ngx_http_request_t *r;
 } ngx_mrb_reentrant_t;
 
-static void replace_stop(mrb_irep *irep)
-{
-  // A part of them refer to https://github.com/h2o/h2o
-  // Replace OP_STOP with OP_RETURN to avoid stop VM
-  irep->iseq[irep->ilen - 1] = MKOP_AB(OP_RETURN, irep->nlocals, OP_R_NORMAL);
-}
-
 void ngx_mrb_run_without_stop(mrb_state *mrb, struct RProc *rproc, mrb_value *result)
 {
   mrb_value mrb_result;
+  mrb_value proc = mrb_obj_value(mrb_proc_new(mrb, rproc->body.irep));
 
-  replace_stop(rproc->body.irep);
-
-  mrb_result = mrb_run(mrb, rproc, mrb_top_self(mrb));
+  mrb_result = mrb_funcall(mrb, proc, "call", 0, NULL);
   if (result != NULL) {
     *result = mrb_result;
   }
@@ -46,7 +38,6 @@ mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RPro
   mrb_value proc;
   mrb_value *fiber;
 
-  replace_stop(rproc->body.irep);
   proc = mrb_obj_value(mrb_closure_new(mrb, rproc->body.irep));
 
   fiber = (mrb_value *)ngx_palloc(r->pool, sizeof(mrb_value));

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -85,6 +85,7 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
     *result = handler_result;
   }
 
+  // leaves the object in the arena
   mrb_gc_protect(mrb, *fiber);
 
   return aliving;

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -58,16 +58,17 @@ mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RPro
   return ngx_mrb_run_fiber(mrb, fiber_proc, result);
 }
 
-mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
+mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber_proc, mrb_value *result)
 {
   mrb_value resume_result = mrb_nil_value();
   ngx_http_request_t *r = ngx_mrb_get_request();
   mrb_value aliving = mrb_false_value();
   mrb_value handler_result = mrb_nil_value();
 
-  mrb->ud = fiber;
+  // Fiber wrapped in proc
+  mrb->ud = fiber_proc;
 
-  resume_result = mrb_funcall(mrb, *fiber, "call", 0, NULL);
+  resume_result = mrb_funcall(mrb, *fiber_proc, "call", 0, NULL);
   if (mrb->exc) {
     ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber",
                   MODULE_NAME, __func__, __LINE__);

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -108,8 +108,8 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
       rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
   } else {
-    ngx_log_error(NGX_LOG_NOTICE, re->r->connection->log, 0, "%s NOTICE %s:%d: unexpected error, fiber missing"
-                  MODULE_NAME, __func__, __LINE__);
+    ngx_log_error(NGX_LOG_NOTICE, re->r->connection->log, 0,
+                  "%s NOTICE %s:%d: unexpected error, fiber missing" MODULE_NAME, __func__, __LINE__);
     rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
   }
 
@@ -123,7 +123,7 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
     rc = NGX_ERROR;
   }
 
-   ngx_http_finalize_request(re->r, rc);
+  ngx_http_finalize_request(re->r, rc);
 }
 
 static void ngx_mrb_async_sleep_cleanup(void *data)

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -80,7 +80,7 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
   }
   aliving = mrb_ary_entry(resume_result, 0);
   handler_result = mrb_ary_entry(resume_result, 1);
-  // result called timer_handler is NULL
+  // result called timer_handler is NULL via ngx_mrb_resume_fiber
   if (result) {
     *result = handler_result;
   }
@@ -91,7 +91,7 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
   return aliving;
 }
 
-#define ngx_mrb_resume_fiber(mrb, fiber, result) ngx_mrb_run_fiber(mrb, fiber, result)
+#define ngx_mrb_resume_fiber(mrb, fiber) ngx_mrb_run_fiber(mrb, fiber, NULL)
 
 static void ngx_mrb_timer_handler(ngx_event_t *ev)
 {
@@ -103,7 +103,7 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
 
   if (re->fiber != NULL) {
     ngx_mrb_push_request(re->r);
-    if (!mrb_test(ngx_mrb_resume_fiber(re->mrb, re->fiber, NULL))) {
+    if (!mrb_test(ngx_mrb_resume_fiber(re->mrb, re->fiber))) {
       re->fiber = NULL;
     }
     if (re->mrb->exc) {

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -67,12 +67,15 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
 
   resume_result = mrb_funcall(mrb, *fiber, "call", 0, NULL);
   if (mrb->exc) {
-    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber", MODULE_NAME, __func__, __LINE__);
+    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber",
+                  MODULE_NAME, __func__, __LINE__);
     return mrb_false_value();
   }
 
   if (!mrb_array_p(resume_result)) {
-    mrb->exc = mrb_obj_ptr(mrb_exc_new_str_lit(mrb, E_RUNTIME_ERROR, "_ngx_mrb_prepare_fiber proc must return array included handler_return and fiber alive status"));
+    mrb->exc = mrb_obj_ptr(mrb_exc_new_str_lit(
+        mrb, E_RUNTIME_ERROR,
+        "_ngx_mrb_prepare_fiber proc must return array included handler_return and fiber alive status"));
     return mrb_false_value();
   }
   aliving = mrb_ary_entry(resume_result, 0);
@@ -125,8 +128,7 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
   }
 }
 
-static void
-ngx_mrb_async_sleep_cleanup(void *data)
+static void ngx_mrb_async_sleep_cleanup(void *data)
 {
   ngx_event_t *ev = (ngx_event_t *)data;
 

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -146,7 +146,7 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   ngx_event_t *ev;
   ngx_mrb_reentrant_t *re;
   ngx_http_cleanup_t *cln;
-  ngx_http_request_t *r = ngx_mrb_get_request();
+  ngx_http_request_t *r;
 
   mrb_get_args(mrb, "i", &timer);
 
@@ -154,6 +154,7 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   // resume the Ruby handler on ngx_mrb_resume_fiber() on ngx_mrb_timer_handler()
   mrb_fiber_yield(mrb, 0, NULL);
 
+  r = ngx_mrb_get_request();
   p = ngx_palloc(r->pool, sizeof(ngx_event_t) + sizeof(ngx_mrb_reentrant_t));
   re = (ngx_mrb_reentrant_t *)(p + sizeof(ngx_event_t));
   re->mrb = mrb;

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -1,0 +1,158 @@
+/*
+// ngx_http_mruby_async.c - ngx_mruby mruby module
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#include "ngx_http_mruby_async.h"
+#include "ngx_http_mruby_core.h"
+#include "ngx_http_mruby_request.h"
+
+#include <nginx.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+#include <mruby/array.h>
+#include <mruby/opcode.h>
+#include <mruby/proc.h>
+
+typedef struct {
+  mrb_state *mrb;
+  mrb_value *fiber;
+  ngx_http_request_t *r;
+} ngx_mrb_reentrant_t;
+
+static void replace_stop(mrb_irep *irep)
+{
+  // A part of them refer to https://github.com/h2o/h2o
+  // Replace OP_STOP with OP_RETURN to avoid stop VM
+  irep->iseq[irep->ilen - 1] = MKOP_AB(OP_RETURN, irep->nlocals, OP_R_NORMAL);
+}
+
+void ngx_mrb_run_without_stop(mrb_state *mrb, struct RProc *rproc, mrb_value *result)
+{
+  mrb_value mrb_result;
+
+  replace_stop(rproc->body.irep);
+
+  mrb_result = mrb_run(mrb, rproc, mrb_top_self(mrb));
+  if (result != NULL) {
+    *result = mrb_result;
+  }
+}
+
+mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RProc *rproc, mrb_value *result)
+{
+  mrb_value proc;
+  mrb_value *fiber;
+
+  replace_stop(rproc->body.irep);
+  proc = mrb_obj_value(mrb_closure_new(mrb, rproc->body.irep));
+
+  fiber = (mrb_value *)ngx_palloc(r->pool, sizeof(mrb_value));
+  *fiber = mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_ngx_mruby_prepare_fiber", 1, proc);
+
+  return ngx_mrb_run_fiber(mrb, fiber, result);
+}
+
+mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
+{
+  mrb_value resume_results = mrb_nil_value();
+  mrb_value is_alive = mrb_false_value();
+
+  mrb->ud = fiber;
+
+  // TODO support passing arguments.
+  resume_results = mrb_funcall(mrb, *fiber, "call", 0, NULL);
+
+  is_alive = mrb_ary_entry(resume_results, 0);
+  if (result != NULL) {
+    *result = mrb_ary_entry(resume_results, 1);
+  }
+
+  if (mrb_test(is_alive)) {
+    mrb_gc_register(mrb, *fiber);
+  } else {
+    mrb_gc_unregister(mrb, *fiber);
+  }
+
+  return is_alive;
+}
+
+static void ngx_mrb_timer_handler(ngx_event_t *ev)
+{
+  ngx_mrb_reentrant_t *re;
+  ngx_http_mruby_ctx_t *ctx;
+  ngx_int_t rc = NGX_OK;
+
+  re = ev->data;
+
+  if (re->fiber != NULL) {
+    ngx_mrb_push_request(re->r);
+    if (!mrb_test(ngx_mrb_run_fiber(re->mrb, re->fiber, NULL))) {
+      re->fiber = NULL;
+    }
+    if (re->mrb->exc) {
+      ngx_mrb_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->r);
+      rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+  }
+
+  ctx = ngx_http_get_module_ctx(re->r, ngx_http_mruby_module);
+  if (ctx != NULL) {
+    if (rc != NGX_OK) {
+      re->r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+    rc = ngx_mrb_finalize_rputs(re->r, ctx);
+  } else {
+    rc = NGX_ERROR;
+  }
+
+  // progress to a next handler or finalize
+  if (rc == NGX_OK) {
+    re->r->phase_handler++;
+    ngx_http_core_run_phases(re->r);
+  } else {
+    ngx_http_finalize_request(re->r, rc);
+  }
+}
+
+static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
+{
+  unsigned int timer;
+  u_char *p;
+  ngx_event_t *ev;
+  ngx_mrb_reentrant_t *re;
+  ngx_http_request_t *r;
+
+  mrb_get_args(mrb, "i", &timer);
+
+  mrb_fiber_yield(mrb, 0, NULL);
+
+  r = ngx_mrb_get_request();
+
+  p = ngx_palloc(r->pool, sizeof(ngx_event_t) + sizeof(ngx_mrb_reentrant_t));
+
+  re = (ngx_mrb_reentrant_t *)(p + sizeof(ngx_event_t));
+  re->mrb = mrb;
+  re->fiber = (mrb_value *)mrb->ud;
+  re->r = r;
+
+  ev = (ngx_event_t *)p;
+  ngx_memzero(ev, sizeof(ngx_event_t));
+  ev->handler = ngx_mrb_timer_handler;
+  ev->data = re;
+  ev->log = ngx_cycle->log;
+
+  ngx_add_timer(ev, (ngx_msec_t)timer);
+
+  return self;
+}
+
+void ngx_mrb_async_class_init(mrb_state *mrb, struct RClass *class)
+{
+  struct RClass *class_async;
+
+  class_async = mrb_define_class_under(mrb, class, "Async", mrb->object_class);
+  mrb_define_class_method(mrb, class_async, "sleep", ngx_mrb_async_sleep, MRB_ARGS_REQ(1));
+}

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -57,11 +57,13 @@ mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RPro
 mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
 {
   mrb_value resume_result = mrb_nil_value();
+  ngx_http_request_t *r = ngx_mrb_get_request();
 
   mrb->ud = fiber;
 
   resume_result = mrb_funcall(mrb, *fiber, "call", 0, NULL);
   if (mrb->exc) {
+    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber", MODULE_NAME, __func__, __LINE__);
     return mrb_false_value();
   }
 

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -145,8 +145,8 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   u_char *p;
   ngx_event_t *ev;
   ngx_mrb_reentrant_t *re;
-  ngx_http_request_t *r;
   ngx_http_cleanup_t *cln;
+  ngx_http_request_t *r = ngx_mrb_get_request();
 
   mrb_get_args(mrb, "i", &timer);
 
@@ -154,10 +154,7 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   // resume the Ruby handler on ngx_mrb_resume_fiber() on ngx_mrb_timer_handler()
   mrb_fiber_yield(mrb, 0, NULL);
 
-  r = ngx_mrb_get_request();
-
   p = ngx_palloc(r->pool, sizeof(ngx_event_t) + sizeof(ngx_mrb_reentrant_t));
-
   re = (ngx_mrb_reentrant_t *)(p + sizeof(ngx_event_t));
   re->mrb = mrb;
   re->fiber = (mrb_value *)mrb->ud;

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -102,8 +102,7 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
     ngx_mrb_push_request(re->r);
 
     if (mrb_test(ngx_mrb_resume_fiber(re->mrb, re->fiber))) {
-      ngx_http_core_run_phases(re->r);
-      ngx_http_run_posted_requests(re->r->connection);
+      // can resume the fiber and wait the epoll timer
       return;
     } else {
       // can not resume the fiber, the fiber was finished

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -91,6 +91,8 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result)
   return aliving;
 }
 
+#define ngx_mrb_resume_fiber(mrb, fiber, result) ngx_mrb_run_fiber(mrb, fiber, result)
+
 static void ngx_mrb_timer_handler(ngx_event_t *ev)
 {
   ngx_mrb_reentrant_t *re;
@@ -101,7 +103,7 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
 
   if (re->fiber != NULL) {
     ngx_mrb_push_request(re->r);
-    if (!mrb_test(ngx_mrb_run_fiber(re->mrb, re->fiber, NULL))) {
+    if (!mrb_test(ngx_mrb_resume_fiber(re->mrb, re->fiber, NULL))) {
       re->fiber = NULL;
     }
     if (re->mrb->exc) {

--- a/src/http/ngx_http_mruby_async.h
+++ b/src/http/ngx_http_mruby_async.h
@@ -1,0 +1,17 @@
+/*
+// ngx_http_mruby_async.h - ngx_mruby mruby module header
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#ifndef NGX_HTTP_MRUBY_ASYNC_H
+#define NGX_HTTP_MRUBY_ASYNC_H
+
+#include <ngx_http.h>
+#include <mruby.h>
+
+void ngx_mrb_run_without_stop(mrb_state *mrb, struct RProc *rproc, mrb_value *result);
+mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RProc *proc, mrb_value *result);
+mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber, mrb_value *result);
+
+#endif // NGX_HTTP_MRUBY_ASYNC_H

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -91,6 +91,36 @@ void ngx_mrb_raise_conf_error(mrb_state *mrb, mrb_value exc, ngx_conf_t *cf)
 #endif
 }
 
+// TODO: Support rputs by multi directive
+ngx_int_t ngx_mrb_finalize_rputs(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ctx)
+{
+  ngx_int_t rc = NGX_OK;
+  ngx_mrb_rputs_chain_list_t *chain;
+
+  chain = ctx->rputs_chain;
+  if (chain == NULL) {
+    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                  "%s INFO %s:%d: mrb_run info: rputs_chain is null and return NGX_OK", MODULE_NAME, __func__,
+                  __LINE__);
+    if (r->headers_out.status >= 100) {
+      rc = r->headers_out.status;
+    } else {
+      rc = NGX_OK;
+    }
+  } else if (r->headers_out.status == NGX_HTTP_OK || !(*chain->last)->buf->last_buf) {
+    r->headers_out.status = NGX_HTTP_OK;
+    (*chain->last)->buf->last_buf = 1;
+    ngx_http_send_header(r);
+    ngx_http_output_filter(r, chain->out);
+    ngx_http_set_ctx(r, NULL, ngx_http_mruby_module);
+    rc = NGX_OK;
+  } else {
+    rc = r->headers_out.status;
+  }
+
+  return rc;
+}
+
 static mrb_value ngx_mrb_send_header(mrb_state *mrb, mrb_value self)
 {
   ngx_mrb_rputs_chain_list_t *chain = NULL;

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -144,9 +144,8 @@ static mrb_value ngx_mrb_send_header(mrb_state *mrb, mrb_value self)
   if (r->headers_out.status == NGX_HTTP_OK) {
     if (chain == NULL) {
       r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
-      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                    "%s ERROR %s: status code is 200, but response body is empty."
-                    " return NGX_HTTP_INTERNAL_SERVER_ERROR",
+      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "%s ERROR %s: status code is 200, but response body is empty."
+                                                        " return NGX_HTTP_INTERNAL_SERVER_ERROR",
                     MODULE_NAME, __func__);
     }
   }

--- a/src/http/ngx_http_mruby_core.h
+++ b/src/http/ngx_http_mruby_core.h
@@ -37,4 +37,6 @@ void ngx_mrb_raise_connection_error(mrb_state *mrb, mrb_value exc, ngx_connectio
 void ngx_mrb_raise_cycle_error(mrb_state *mrb, mrb_value obj, ngx_cycle_t *cycle);
 void ngx_mrb_raise_conf_error(mrb_state *mrb, mrb_value obj, ngx_conf_t *cf);
 
+ngx_int_t ngx_mrb_finalize_rputs(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ctx);
+
 #endif // NGX_HTTP_MRUBY_CORE_H

--- a/src/http/ngx_http_mruby_init.c
+++ b/src/http/ngx_http_mruby_init.c
@@ -29,6 +29,9 @@ void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *calss);
 #if (NGX_HTTP_SSL)
 void ngx_mrb_ssl_class_init(mrb_state *mrb, struct RClass *class);
 #endif
+#ifdef NGX_USE_MRUBY_ASYNC
+void ngx_mrb_async_class_init(mrb_state *mrb, struct RClass *calss);
+#endif
 
 ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
 {
@@ -54,6 +57,10 @@ ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
 #endif
 #if (NGX_HTTP_SSL)
   ngx_mrb_ssl_class_init(mrb, class);
+  GC_ARENA_RESTORE;
+#endif
+#ifdef NGX_USE_MRUBY_ASYNC
+  ngx_mrb_async_class_init(mrb, class);
   GC_ARENA_RESTORE;
 #endif
 

--- a/src/http/ngx_http_mruby_init.c
+++ b/src/http/ngx_http_mruby_init.c
@@ -29,9 +29,7 @@ void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *calss);
 #if (NGX_HTTP_SSL)
 void ngx_mrb_ssl_class_init(mrb_state *mrb, struct RClass *class);
 #endif
-#ifdef NGX_USE_MRUBY_ASYNC
 void ngx_mrb_async_class_init(mrb_state *mrb, struct RClass *calss);
-#endif
 
 ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
 {
@@ -59,10 +57,8 @@ ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
   ngx_mrb_ssl_class_init(mrb, class);
   GC_ARENA_RESTORE;
 #endif
-#ifdef NGX_USE_MRUBY_ASYNC
   ngx_mrb_async_class_init(mrb, class);
   GC_ARENA_RESTORE;
-#endif
 
   return NGX_OK;
 }

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -846,9 +846,9 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_mrb_cod
   }
 
   if (mrb_test(ngx_mrb_start_fiber(r, state->mrb, code->proc, &mrb_result))) {
+    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME, __func__, __LINE__);
     return NGX_DONE;
   }
-  //mrb_result = mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
 
   if (state->mrb->exc) {
     ngx_mrb_raise_error(state->mrb, mrb_obj_value(state->mrb->exc), r);

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -13,10 +13,7 @@
 #include "ngx_http_mruby_core.h"
 #include "ngx_http_mruby_module.h"
 #include "ngx_http_mruby_request.h"
-
-#ifdef NGX_USE_MRUBY_ASYNC
 #include "ngx_http_mruby_async.h"
-#endif
 
 #include <mruby.h>
 #include <mruby/array.h>
@@ -735,11 +732,9 @@ ngx_int_t ngx_mrb_run_cycle(ngx_cycle_t *cycle, ngx_mrb_state_t *state, ngx_mrb_
 {
   int ai = mrb_gc_arena_save(state->mrb);
   ngx_log_error(NGX_LOG_INFO, cycle->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
-#ifdef NGX_USE_MRUBY_ASYNC
+
   ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
-#else
-  mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
-#endif
+  //mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
     ngx_mrb_raise_cycle_error(state->mrb, mrb_obj_value(state->mrb->exc), cycle);
@@ -755,11 +750,8 @@ ngx_int_t ngx_mrb_run_conf(ngx_conf_t *cf, ngx_mrb_state_t *state, ngx_mrb_code_
 {
   int ai = mrb_gc_arena_save(state->mrb);
   ngx_log_error(NGX_LOG_INFO, cf->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
-#ifdef NGX_USE_MRUBY_ASYNC
   ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
-#else
-  mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
-#endif
+  //mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
@@ -853,13 +845,10 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_mrb_cod
     }
   }
 
-#ifdef NGX_USE_MRUBY_ASYNC
   if (mrb_test(ngx_mrb_start_fiber(r, state->mrb, code->proc, &mrb_result))) {
     return NGX_DONE;
   }
-#else
-  mrb_result = mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
-#endif
+  //mrb_result = mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
 
   if (state->mrb->exc) {
     ngx_mrb_raise_error(state->mrb, mrb_obj_value(state->mrb->exc), r);
@@ -2160,18 +2149,12 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
         return 1;
       }
     }
-#ifdef NGX_USE_MRUBY_ASYNC
     ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_code->proc, NULL);
-#else
-    mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
-#endif
+    //mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
   }
   if (mscf->ssl_handshake_inline_code != NGX_CONF_UNSET_PTR) {
-#ifdef NGX_USE_MRUBY_ASYNC
     ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_inline_code->proc, NULL);
-#else
-    mrb_run(mrb, mscf->ssl_handshake_inline_code->proc, mrb_top_self(mrb));
-#endif
+    //mrb_run(mrb, mscf->ssl_handshake_inline_code->proc, mrb_top_self(mrb));
   }
 
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(mrb, mscf->ssl_handshake_code);

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -846,6 +846,9 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_mrb_cod
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME,
                   __func__, __LINE__);
     return NGX_DONE;
+  } else {
+    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0, "%s INFO %s:%d: already finish this fiber, can not resume",
+                  MODULE_NAME, __func__, __LINE__);
   }
 
   if (state->mrb->exc) {

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -2093,8 +2093,9 @@ NGX_MRUBY_SSL_ERROR:
 
 #endif /* NGX_HTTP_SSL */
 
-#if (NGX_HTTP_SSL) && OPENSSL_VERSION_NUMBER >= 0x1000205fL
+#if (NGX_HTTP_SSL) 
 
+#if OPENSSL_VERSION_NUMBER >= 0x1000205fL
 static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 {
   ngx_connection_t *c;
@@ -2220,4 +2221,5 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
 
   return 1;
 }
+#endif /* 0x1000205fL */
 #endif /* NGX_HTTP_SSL */

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -731,7 +731,6 @@ ngx_int_t ngx_mrb_run_cycle(ngx_cycle_t *cycle, ngx_mrb_state_t *state, ngx_mrb_
   ngx_log_error(NGX_LOG_INFO, cycle->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
 
   ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
-  // mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
     ngx_mrb_raise_cycle_error(state->mrb, mrb_obj_value(state->mrb->exc), cycle);
@@ -748,7 +747,6 @@ ngx_int_t ngx_mrb_run_conf(ngx_conf_t *cf, ngx_mrb_state_t *state, ngx_mrb_code_
   int ai = mrb_gc_arena_save(state->mrb);
   ngx_log_error(NGX_LOG_INFO, cf->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
   ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
-  // mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
@@ -2151,11 +2149,9 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
       }
     }
     ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_code->proc, NULL);
-    // mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
   }
   if (mscf->ssl_handshake_inline_code != NGX_CONF_UNSET_PTR) {
     ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_inline_code->proc, NULL);
-    // mrb_run(mrb, mscf->ssl_handshake_inline_code->proc, mrb_top_self(mrb));
   }
 
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(mrb, mscf->ssl_handshake_code);

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -853,6 +853,8 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_mrb_cod
     r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
     mrb_gc_arena_restore(state->mrb, ai);
   } else if (result != NULL) {
+    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0, "%s INFO %s:%d: fiber done in request phase", MODULE_NAME,
+                  __func__, __LINE__);
     if (mrb_nil_p(mrb_result)) {
       result->data = NULL;
       result->len = 0;

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -434,8 +434,7 @@ static char *ngx_http_mruby_merge_srv_conf(ngx_conf_t *cf, void *parent, void *c
 #if OPENSSL_VERSION_NUMBER >= 0x1000205fL
     SSL_CTX_set_cert_cb(sscf->ssl.ctx, ngx_http_mruby_ssl_cert_handler, NULL);
 #else
-    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                  MODULE_NAME
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0, MODULE_NAME
                   " : mruby_ssl_handshake_handler : OpenSSL 1.0.2e or later required but found " OPENSSL_VERSION_TEXT);
     return NGX_CONF_ERROR;
 #endif
@@ -637,15 +636,13 @@ static ngx_int_t ngx_http_mruby_handler_init(ngx_http_core_main_conf_t *cmcf)
   ngx_http_phases phases[] = {
       NGX_HTTP_POST_READ_PHASE,
       // NGX_HTTP_FIND_CONFIG_PHASE,
-      NGX_HTTP_SERVER_REWRITE_PHASE,
-      NGX_HTTP_REWRITE_PHASE,
+      NGX_HTTP_SERVER_REWRITE_PHASE, NGX_HTTP_REWRITE_PHASE,
       // NGX_HTTP_POST_REWRITE_PHASE,
       // NGX_HTTP_PREACCESS_PHASE,
       NGX_HTTP_ACCESS_PHASE,
       // NGX_HTTP_POST_ACCESS_PHASE,
       // NGX_HTTP_TRY_FILES_PHASE,
-      NGX_HTTP_CONTENT_PHASE,
-      NGX_HTTP_LOG_PHASE,
+      NGX_HTTP_CONTENT_PHASE, NGX_HTTP_LOG_PHASE,
   };
   ngx_int_t phases_c;
 
@@ -734,7 +731,7 @@ ngx_int_t ngx_mrb_run_cycle(ngx_cycle_t *cycle, ngx_mrb_state_t *state, ngx_mrb_
   ngx_log_error(NGX_LOG_INFO, cycle->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
 
   ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
-  //mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
+  // mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
     ngx_mrb_raise_cycle_error(state->mrb, mrb_obj_value(state->mrb->exc), cycle);
@@ -751,7 +748,7 @@ ngx_int_t ngx_mrb_run_conf(ngx_conf_t *cf, ngx_mrb_state_t *state, ngx_mrb_code_
   int ai = mrb_gc_arena_save(state->mrb);
   ngx_log_error(NGX_LOG_INFO, cf->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
   ngx_mrb_run_without_stop(state->mrb, code->proc, NULL);
-  //mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
+  // mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
   if (state->mrb->exc) {
@@ -846,7 +843,8 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_mrb_cod
   }
 
   if (mrb_test(ngx_mrb_start_fiber(r, state->mrb, code->proc, &mrb_result))) {
-    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME, __func__, __LINE__);
+    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME,
+                  __func__, __LINE__);
     return NGX_DONE;
   }
 
@@ -1017,9 +1015,8 @@ static ngx_int_t ngx_http_mruby_shared_state_compile(ngx_conf_t *cf, ngx_mrb_sta
     ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: code->code.file=(%s) code->cache=(%d)",
                        MODULE_NAME, __func__, __LINE__, code->code.file, code->cache);
   } else {
-    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
-                       "%s NOTICE %s:%d: compile info: "
-                       "code->code.string=(%s) code->cache=(%d)",
+    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: "
+                                              "code->code.string=(%s) code->cache=(%d)",
                        MODULE_NAME, __func__, __LINE__, code->code.string, code->cache);
   }
 
@@ -1186,10 +1183,9 @@ static char *ngx_http_mruby_exit_worker_inline(ngx_conf_t *cf, ngx_command_t *cm
 
 static char *ngx_http_mruby_output_filter_error(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-  ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                     "mruby_output_filter{,_code} was deleted from v1.17.2, you should use "
-                     "mruby_output_body_filter{,_code} for response body, or use "
-                     "mruby_output_header_filter{,_code} for response headers.");
+  ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mruby_output_filter{,_code} was deleted from v1.17.2, you should use "
+                                           "mruby_output_body_filter{,_code} for response body, or use "
+                                           "mruby_output_header_filter{,_code} for response headers.");
   return NGX_CONF_ERROR;
 }
 
@@ -2082,7 +2078,7 @@ NGX_MRUBY_SSL_ERROR:
 
 #endif /* NGX_HTTP_SSL */
 
-#if (NGX_HTTP_SSL) 
+#if (NGX_HTTP_SSL)
 
 #if OPENSSL_VERSION_NUMBER >= 0x1000205fL
 static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
@@ -2150,11 +2146,11 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
       }
     }
     ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_code->proc, NULL);
-    //mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
+    // mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
   }
   if (mscf->ssl_handshake_inline_code != NGX_CONF_UNSET_PTR) {
     ngx_mrb_run_without_stop(mrb, mscf->ssl_handshake_inline_code->proc, NULL);
-    //mrb_run(mrb, mscf->ssl_handshake_inline_code->proc, mrb_top_self(mrb));
+    // mrb_run(mrb, mscf->ssl_handshake_inline_code->proc, mrb_top_self(mrb));
   }
 
   NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(mrb, mscf->ssl_handshake_code);

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -26,6 +26,8 @@
 #define NGX_USE_MRUBY_UPSTREAM
 #endif
 
+#define NGX_USE_MRUBY_ASYNC
+
 typedef enum code_type_t { NGX_MRB_CODE_TYPE_FILE, NGX_MRB_CODE_TYPE_STRING } code_type_t;
 
 typedef struct ngx_mrb_state_t {

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -26,8 +26,6 @@
 #define NGX_USE_MRUBY_UPSTREAM
 #endif
 
-#define NGX_USE_MRUBY_ASYNC
-
 typedef enum code_type_t { NGX_MRB_CODE_TYPE_FILE, NGX_MRB_CODE_TYPE_STRING } code_type_t;
 
 typedef struct ngx_mrb_state_t {

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -20,7 +20,7 @@
 #include "ngx_http_mruby_init.h"
 
 #define MODULE_NAME "ngx_mruby"
-#define MODULE_VERSION "1.20.2"
+#define MODULE_VERSION "2.0.0-dev"
 
 #if (nginx_version > 1007999)
 #define NGX_USE_MRUBY_UPSTREAM

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -20,7 +20,7 @@
 #include "ngx_http_mruby_init.h"
 
 #define MODULE_NAME "ngx_mruby"
-#define MODULE_VERSION "1.20.1"
+#define MODULE_VERSION "1.20.2"
 
 #if (nginx_version > 1007999)
 #define NGX_USE_MRUBY_UPSTREAM

--- a/src/http/ngx_http_mruby_request.c
+++ b/src/http/ngx_http_mruby_request.c
@@ -122,9 +122,8 @@ static mrb_value ngx_mrb_read_request_body(mrb_state *mrb, mrb_value self)
   ngx_http_request_t *r = ngx_mrb_get_request();
 
   if (r->method != NGX_HTTP_POST && r->method != NGX_HTTP_PUT) {
-    mrb_raise(mrb, E_RUNTIME_ERROR,
-              "ngx_mrb_read_request_body can't read"
-              " when r->method is neither POST nor PUT");
+    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_mrb_read_request_body can't read"
+                                    " when r->method is neither POST nor PUT");
   }
 
   return self;
@@ -136,9 +135,8 @@ static mrb_value ngx_mrb_get_request_body(mrb_state *mrb, mrb_value self)
   ngx_http_request_t *r = ngx_mrb_get_request();
 
   if (r->method != NGX_HTTP_POST && r->method != NGX_HTTP_PUT) {
-    mrb_raise(mrb, E_RUNTIME_ERROR,
-              "ngx_mrb_read_request_body can't read"
-              " when r->method is neither POST nor PUT");
+    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_mrb_read_request_body can't read"
+                                    " when r->method is neither POST nor PUT");
   }
 
   return mrb_funcall(mrb, v, "request_body", 0, NULL);
@@ -268,7 +266,7 @@ static ngx_int_t ngx_mrb_set_request_header(mrb_state *mrb, ngx_list_t *headers,
     r->headers_out.server->value.len = val_len;
     break;
 
-    // TODO: Add other built-in headers
+  // TODO: Add other built-in headers
 
   default:
     break;

--- a/src/http/ngx_http_mruby_upstream.c
+++ b/src/http/ngx_http_mruby_upstream.c
@@ -34,8 +34,7 @@ static void ngx_mrb_upstream_context_free(mrb_state *mrb, void *p)
 }
 
 static const struct mrb_data_type ngx_mrb_upstream_context_type = {
-    "ngx_mrb_upstream_context",
-    ngx_mrb_upstream_context_free,
+    "ngx_mrb_upstream_context", ngx_mrb_upstream_context_free,
 };
 
 static mrb_value ngx_mrb_upstream_init(mrb_state *mrb, mrb_value self)

--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -31,8 +31,7 @@ static void ngx_stream_mrb_upstream_context_free(mrb_state *mrb, void *p)
 }
 
 static const struct mrb_data_type ngx_stream_mrb_upstream_context_type = {
-    "ngx_stream_mrb_upstream_context",
-    ngx_stream_mrb_upstream_context_free,
+    "ngx_stream_mrb_upstream_context", ngx_stream_mrb_upstream_context_free,
 };
 
 static mrb_value ngx_stream_mrb_connection_init(mrb_state *mrb, mrb_value self)

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -400,9 +400,8 @@ static ngx_int_t ngx_stream_mruby_shared_state_compile(ngx_conf_t *cf, mrb_state
     ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: code->code.file=(%s)", MODULE_NAME,
                        __func__, __LINE__, code->code.file);
   } else {
-    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
-                       "%s NOTICE %s:%d: compile info: "
-                       "code->code.string=(%s)",
+    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: "
+                                              "code->code.string=(%s)",
                        MODULE_NAME, __func__, __LINE__, code->code.string);
   }
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -794,6 +794,24 @@ http {
               Nginx.return Nginx::HTTP_OK
             ';
         }
+
+        location /async_sleep_loop {
+            mruby_rewrite_handler_code '
+              5.times do |s|
+                Nginx::Async.sleep 500
+                Nginx.rputs s
+              end
+              Nginx.return Nginx::HTTP_OK
+            ';
+        }
+
+        location /enable_return {
+            mruby_content_handler_code '
+              Nginx.rputs"hoge"
+              return if true
+              Nginx.rputs "foo"
+            ';
+        }
     }
 
     server {

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -786,6 +786,14 @@ http {
         location /backtrace {
           mruby_content_handler build/nginx/html/backtrace.rb;
         }
+
+        location /async_sleep {
+            mruby_rewrite_handler_code '
+              Nginx::Async.sleep 1000
+              Nginx.rputs "body"
+              Nginx.return Nginx::HTTP_OK
+            ';
+        }
     }
 
     server {

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -789,7 +789,7 @@ http {
 
         location /async_sleep {
             mruby_rewrite_handler_code '
-              Nginx::Async.sleep 1000
+              Nginx::Async.sleep 3000
               Nginx.rputs "body"
               Nginx.return Nginx::HTTP_OK
             ';

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -638,6 +638,18 @@ if nginx_features.is_async_supported?
     t.assert_equal 'body', res["body"]
     t.assert_equal 200, res.code
   end
+
+  t.assert('ngx_mruby - Nginx.Async.sleep looping', 'location /async_sleep_loop') do
+    res = HttpRequest.new.get base + '/async_sleep_loop'
+    t.assert_equal '01234', res["body"]
+    t.assert_equal 200, res.code
+  end
+
+  t.assert('ngx_mruby - enable return method', 'location /enable_return') do
+    res = HttpRequest.new.get base + '/enable_return'
+    t.assert_equal 'hoge', res["body"]
+    t.assert_equal 200, res.code
+  end
 end
 
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -38,6 +38,10 @@ class NginxFeatures
     # 1.9.6 or later
     @minor >= 10 || (@minor == 9 && @patch >= 6)
   end
+  def is_async_supported?
+    # Should we enable Nginx::Async as default?
+    true
+  end
 end
 
 t = SimpleTest.new "ngx_mruby test"
@@ -627,5 +631,13 @@ if nginx_features.is_stream_supported?
     t.assert_equal 'Hello ngx_mruby world!', res["body"]
   end
 end
+
+if nginx_features.is_async_supported?
+  t.assert('ngx_mruby - Nginx.Async.sleep', 'location /async_sleep') do
+    res = HttpRequest.new.get base + '/async_sleep'
+    t.assert_equal 200, res.code
+  end
+end
+
 
 t.report

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -453,12 +453,12 @@ t.assert('ngx_mruby - get post_args', 'location /get_post_args') do
 end
 
 t.assert('ngx_mruby - ssl local port') do
-  res = `curl -k #{base_ssl(58082) + '/local_port'}`
+  res = `curl -s -k #{base_ssl(58082) + '/local_port'}`
   t.assert_equal '58082', res
 end
 
 t.assert('ngx_mruby - ssl certificate changing') do
-  res = `curl -k #{base_ssl(58082) + '/'}`
+  res = `curl -s -k #{base_ssl(58082) + '/'}`
   t.assert_equal 'ssl test ok', res
   res = `openssl s_client -servername localhost -connect localhost:58082 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
   t.assert_equal "1", res
@@ -467,7 +467,7 @@ t.assert('ngx_mruby - ssl certificate changing') do
 end
 
 t.assert('ngx_mruby - ssl certificate changing using data instead of file') do
-  res = `curl -k #{base_ssl(58083) + '/'}`
+  res = `curl -s -k #{base_ssl(58083) + '/'}`
   t.assert_equal 'ssl test ok', res
   res = `openssl s_client -servername localhost -connect localhost:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
   t.assert_equal "1", res
@@ -478,7 +478,7 @@ end
 t.assert('ngx_mruby - ssl certificate changing - reading handler from file without caching') do
   fname = File.join(ENV['NGINX_INSTALL_DIR'], 'html/set_ssl_cert_and_key.rb')
 
-  res = `curl -k #{base_ssl(58085) + '/'}`
+  res = `curl -s -k #{base_ssl(58085) + '/'}`
   t.assert_equal 'ssl test ok', res
 
   content = File.read(fname).gsub('#{ssl.servername}', 'localhost')
@@ -499,7 +499,7 @@ end
 t.assert('ngx_mruby - ssl certificate changing - reading handler from file with caching') do
   fname = File.join(ENV['NGINX_INSTALL_DIR'], 'html/set_ssl_cert_and_key.rb')
 
-  res = `curl -k #{base_ssl(58086) + '/'}`
+  res = `curl -s -k #{base_ssl(58086) + '/'}`
   t.assert_equal 'ssl test ok', res
 
   content = File.read(fname).gsub('#{ssl.servername}', 'localhost')
@@ -593,7 +593,7 @@ t.assert('ngx_mruby - add_listener test', 'location /add_listener') do
   t.assert_equal 'add_listener test ok', res["body"]
   res = HttpRequest.new.get base(58102) + '/add_listener'
   t.assert_equal 'add_listener test ok', res["body"]
-  res = `curl -k #{base_ssl(58103) + '/add_listener'}`
+  res = `curl -s -k #{base_ssl(58103) + '/add_listener'}`
   t.assert_equal 'add_listener test ok', res
 end
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -633,10 +633,10 @@ if nginx_features.is_stream_supported?
 end
 
 if nginx_features.is_async_supported?
-  t.assert('ngx_mruby - Nginx.Async.sleep', 'location /async_sleep') do
-    res = HttpRequest.new.get base + '/async_sleep'
-    t.assert_equal 200, res.code
-  end
+  #t.assert('ngx_mruby - Nginx.Async.sleep', 'location /async_sleep') do
+  #  res = HttpRequest.new.get base + '/async_sleep'
+  #  t.assert_equal 200, res.code
+  #end
 end
 
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -633,10 +633,11 @@ if nginx_features.is_stream_supported?
 end
 
 if nginx_features.is_async_supported?
-  #t.assert('ngx_mruby - Nginx.Async.sleep', 'location /async_sleep') do
-  #  res = HttpRequest.new.get base + '/async_sleep'
-  #  t.assert_equal 200, res.code
-  #end
+  t.assert('ngx_mruby - Nginx.Async.sleep', 'location /async_sleep') do
+    res = HttpRequest.new.get base + '/async_sleep'
+    t.assert_equal 'body', res["body"]
+    t.assert_equal 200, res.code
+  end
 end
 
 


### PR DESCRIPTION
- [x] Support all request processing handler on fiber
- [x] Support `Nginx::Async.sleep`

## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
