### PR TITLE
Remove iij/mruby-pack in test

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -79,7 +79,6 @@ MRuby::Build.new('test') do |conf|
   conf.gem :github => 'matsumotory/mruby-simpletest'
   conf.gem :github => 'mattn/mruby-http'
   conf.gem :github => 'mattn/mruby-json'
-  conf.gem :github => 'iij/mruby-pack'
   conf.gem :github => 'iij/mruby-env'
 
   # include the default GEMs


### PR DESCRIPTION
it's related to the following commit: f104e4867e578b2192f1b951c302ba3c5901cce3


- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).