### PR TITLE
fix stack smashing detected

### DIFF
--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -149,7 +149,7 @@ static void ngx_mrb_async_sleep_cleanup(void *data)
 
 static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
 {
-  unsigned int timer;
+  mrb_int timer;
   u_char *p;
   ngx_event_t *ev;
   ngx_mrb_reentrant_t *re;

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -158,6 +158,10 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "i", &timer);
 
+  if (timer < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "value of the timer must be a positive number");
+  }
+
   // suspend the Ruby handler on Nginx::Async.sleep
   // resume the Ruby handler on ngx_mrb_resume_fiber() on ngx_mrb_timer_handler()
   mrb_fiber_yield(mrb, 0, NULL);

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -158,7 +158,7 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "i", &timer);
 
-  if (timer < 0) {
+  if (timer <= 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "value of the timer must be a positive number");
   }
 


### PR DESCRIPTION
v2-devにおいて高負荷時に `*** stack smashing detected ***: nginx: worker process terminated` のエラーログとともにwarkerが終了する不具合がありました。timerの値を受け取る型を変更することで症状の改善が認められたので対応しました。

## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
