### PR TITLE
[WIP]Except when returning early when using Fiber is an exception

### DIFF
--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -17,8 +17,6 @@
 #include <mruby/proc.h>
 #include <mruby/error.h>
 
-#define ngx_mrb_resume_fiber(mrb, fiber) ngx_mrb_run_fiber(mrb, fiber, NULL)
-
 typedef struct {
   mrb_state *mrb;
   mrb_value *fiber;
@@ -49,6 +47,13 @@ mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RPro
 {
   mrb_value handler_proc;
   mrb_value *fiber_proc;
+  ngx_http_mruby_ctx_t *ctx;
+
+  ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
+  if (ctx == NULL) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_http_get_module_ctx failed");
+  }
+  ctx->async_handler_result = result;
 
   replace_stop(rproc->body.irep);
   handler_proc = mrb_obj_value(mrb_proc_new(mrb, rproc->body.irep));
@@ -83,8 +88,8 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber_proc, mrb_value *re
   }
   aliving = mrb_ary_entry(resume_result, 0);
   handler_result = mrb_ary_entry(resume_result, 1);
-  // result called timer_handler is NULL via ngx_mrb_resume_fiber
-  if (result) {
+
+  if (!mrb_test(aliving)) {
     *result = handler_result;
   }
 
@@ -98,37 +103,38 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
   ngx_int_t rc = NGX_OK;
 
   re = ev->data;
+  ctx = ngx_http_get_module_ctx(re->r, ngx_http_mruby_module);
 
-  if (re->fiber != NULL) {
-    ngx_mrb_push_request(re->r);
+  if (ctx != NULL) {
+    if (re->fiber != NULL) {
+      ngx_mrb_push_request(re->r);
 
-    if (mrb_test(ngx_mrb_resume_fiber(re->mrb, re->fiber))) {
-      // can resume the fiber and wait the epoll timer
-      return;
+      if (mrb_test(ngx_mrb_run_fiber(re->mrb, re->fiber, ctx->async_handler_result))) {
+        // can resume the fiber and wait the epoll timer
+        return;
+      } else {
+        // can not resume the fiber, the fiber was finished
+        mrb_gc_unregister(re->mrb, *re->fiber);
+        re->fiber = NULL;
+      }
+
+      ngx_http_run_posted_requests(re->r->connection);
+
+      if (re->mrb->exc) {
+        ngx_mrb_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->r);
+        rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+      }
+
     } else {
-      // can not resume the fiber, the fiber was finished
-      mrb_gc_unregister(re->mrb, *re->fiber);
-      re->fiber = NULL;
-    }
-
-    ngx_http_run_posted_requests(re->r->connection);
-
-    if (re->mrb->exc) {
-      ngx_mrb_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->r);
+      ngx_log_error(NGX_LOG_NOTICE, re->r->connection->log, 0,
+                    "%s NOTICE %s:%d: unexpected error, fiber missing" MODULE_NAME, __func__, __LINE__);
       rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-  } else {
-    ngx_log_error(NGX_LOG_NOTICE, re->r->connection->log, 0,
-                  "%s NOTICE %s:%d: unexpected error, fiber missing" MODULE_NAME, __func__, __LINE__);
-    rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-  }
-
-  ctx = ngx_http_get_module_ctx(re->r, ngx_http_mruby_module);
-  if (ctx != NULL) {
     if (rc != NGX_OK) {
       re->r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
+
     rc = ngx_mrb_finalize_rputs(re->r, ctx);
   } else {
     rc = NGX_ERROR;
@@ -159,7 +165,7 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "i", &timer);
 
   // suspend the Ruby handler on Nginx::Async.sleep
-  // resume the Ruby handler on ngx_mrb_resume_fiber() on ngx_mrb_timer_handler()
+  // resume the Ruby handler on on ngx_mrb_timer_handler()
   mrb_fiber_yield(mrb, 0, NULL);
 
   r = ngx_mrb_get_request();

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -140,6 +140,11 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
     rc = NGX_ERROR;
   }
 
+  if (rc == NGX_DECLINED) {
+      re->r->phase_handler++;
+      ngx_http_core_run_phases(re->r);
+      return;
+  }
   ngx_http_finalize_request(re->r, rc);
 }
 

--- a/src/http/ngx_http_mruby_core.h
+++ b/src/http/ngx_http_mruby_core.h
@@ -30,6 +30,7 @@ typedef struct ngx_http_mruby_ctx_t {
   unsigned request_body_more : 1;
   unsigned read_request_body_done : 1;
   ngx_uint_t phase;
+  mrb_value *async_handler_result;
 } ngx_http_mruby_ctx_t;
 
 void ngx_mrb_raise_error(mrb_state *mrb, mrb_value obj, ngx_http_request_t *r);

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -812,6 +812,20 @@ http {
               Nginx.rputs "foo"
             ';
         }
+
+        location /early_return {
+          mruby_rewrite_handler_code '
+            Nginx::Async.sleep 3000
+            u = Nginx::Upstream.new "mruby_upstream"
+            u.server = "127.0.0.1:58081"
+          ';
+          proxy_pass http://mruby_upstream/;
+          proxy_http_version 1.1;
+          proxy_set_header Connection "";
+          proxy_send_timeout 2s;
+          proxy_read_timeout 2s;
+          proxy_connect_timeout 2s;
+        }
     }
 
     server {

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -650,6 +650,12 @@ if nginx_features.is_async_supported?
     t.assert_equal 'hoge', res["body"]
     t.assert_equal 200, res.code
   end
+
+  t.assert('ngx_mruby - early return method', 'location /early_return') do
+    res = HttpRequest.new.get base + '/early_return'
+    t.assert_equal 'proxy test ok', res["body"]
+    t.assert_equal 200, res.code
+  end
 end
 
 


### PR DESCRIPTION
## Pull-Request Check List
`Nginx::Async.sleep` 利用時にmrubyのreturnを実行するとLocalJumbエラーが発生する。

```
unexpected return (LocalJumpError)
```

Except when returning early when using Fiber is an exception

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
