### PR TITLE
Support async setcode

### DIFF
--- a/dependence/ngx_devel_kit/src/ndk_set_var.c
+++ b/dependence/ngx_devel_kit/src/ndk_set_var.c
@@ -68,8 +68,10 @@ ndk_set_var_code_finalize(ngx_http_script_engine_t *e, ngx_int_t rc,
         v->no_cacheable = 1;
         break;
 
+    case NGX_DONE:
+        e->status = NGX_DONE;
+        break;
     case NGX_ERROR:
-
         e->ip = ndk_http_script_exit;
         e->status = NGX_HTTP_INTERNAL_SERVER_ERROR;
         break;

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -7,6 +7,7 @@
 #include "ngx_http_mruby_async.h"
 #include "ngx_http_mruby_core.h"
 #include "ngx_http_mruby_request.h"
+#include "ngx_http_mruby_var.h"
 
 #include <nginx.h>
 #include <ngx_core.h>
@@ -123,6 +124,12 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
       if (re->mrb->exc) {
         ngx_mrb_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->r);
         rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+      }
+
+      if (ctx->set_var_target.len > 0) {
+        // Delete the leading dollar(ctx->set_var_target.data+1)
+        ngx_mrb_var_set(re->mrb, mrb_top_self(re->mrb), (char *)ctx->set_var_target.data + 1,
+                        *ctx->async_handler_result, re->r);
       }
 
     } else {

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -128,8 +128,8 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
 
       if (ctx->set_var_target.len > 0) {
         // Delete the leading dollar(ctx->set_var_target.data+1)
-        ngx_mrb_var_set(re->mrb, mrb_top_self(re->mrb), (char *)ctx->set_var_target.data + 1,
-                        *ctx->async_handler_result, re->r);
+        ngx_mrb_var_set_vector(re->mrb, mrb_top_self(re->mrb), (char *)ctx->set_var_target.data + 1,
+                               ctx->set_var_target.len - 1, *ctx->async_handler_result, re->r);
       }
 
     } else {

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -144,8 +144,9 @@ static mrb_value ngx_mrb_send_header(mrb_state *mrb, mrb_value self)
   if (r->headers_out.status == NGX_HTTP_OK) {
     if (chain == NULL) {
       r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
-      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "%s ERROR %s: status code is 200, but response body is empty."
-                                                        " return NGX_HTTP_INTERNAL_SERVER_ERROR",
+      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                    "%s ERROR %s: status code is 200, but response body is empty."
+                    " return NGX_HTTP_INTERNAL_SERVER_ERROR",
                     MODULE_NAME, __func__);
     }
   }

--- a/src/http/ngx_http_mruby_core.h
+++ b/src/http/ngx_http_mruby_core.h
@@ -31,6 +31,7 @@ typedef struct ngx_http_mruby_ctx_t {
   unsigned read_request_body_done : 1;
   ngx_uint_t phase;
   mrb_value *async_handler_result;
+  ngx_str_t set_var_target;
 } ngx_http_mruby_ctx_t;
 
 void ngx_mrb_raise_error(mrb_state *mrb, mrb_value obj, ngx_http_request_t *r);

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -434,7 +434,8 @@ static char *ngx_http_mruby_merge_srv_conf(ngx_conf_t *cf, void *parent, void *c
 #if OPENSSL_VERSION_NUMBER >= 0x1000205fL
     SSL_CTX_set_cert_cb(sscf->ssl.ctx, ngx_http_mruby_ssl_cert_handler, NULL);
 #else
-    ngx_log_error(NGX_LOG_EMERG, cf->log, 0, MODULE_NAME
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  MODULE_NAME
                   " : mruby_ssl_handshake_handler : OpenSSL 1.0.2e or later required but found " OPENSSL_VERSION_TEXT);
     return NGX_CONF_ERROR;
 #endif
@@ -636,13 +637,15 @@ static ngx_int_t ngx_http_mruby_handler_init(ngx_http_core_main_conf_t *cmcf)
   ngx_http_phases phases[] = {
       NGX_HTTP_POST_READ_PHASE,
       // NGX_HTTP_FIND_CONFIG_PHASE,
-      NGX_HTTP_SERVER_REWRITE_PHASE, NGX_HTTP_REWRITE_PHASE,
+      NGX_HTTP_SERVER_REWRITE_PHASE,
+      NGX_HTTP_REWRITE_PHASE,
       // NGX_HTTP_POST_REWRITE_PHASE,
       // NGX_HTTP_PREACCESS_PHASE,
       NGX_HTTP_ACCESS_PHASE,
       // NGX_HTTP_POST_ACCESS_PHASE,
       // NGX_HTTP_TRY_FILES_PHASE,
-      NGX_HTTP_CONTENT_PHASE, NGX_HTTP_LOG_PHASE,
+      NGX_HTTP_CONTENT_PHASE,
+      NGX_HTTP_LOG_PHASE,
   };
   ngx_int_t phases_c;
 
@@ -1018,8 +1021,9 @@ static ngx_int_t ngx_http_mruby_shared_state_compile(ngx_conf_t *cf, ngx_mrb_sta
     ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: code->code.file=(%s) code->cache=(%d)",
                        MODULE_NAME, __func__, __LINE__, code->code.file, code->cache);
   } else {
-    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: "
-                                              "code->code.string=(%s) code->cache=(%d)",
+    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
+                       "%s NOTICE %s:%d: compile info: "
+                       "code->code.string=(%s) code->cache=(%d)",
                        MODULE_NAME, __func__, __LINE__, code->code.string, code->cache);
   }
 
@@ -1186,9 +1190,10 @@ static char *ngx_http_mruby_exit_worker_inline(ngx_conf_t *cf, ngx_command_t *cm
 
 static char *ngx_http_mruby_output_filter_error(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-  ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mruby_output_filter{,_code} was deleted from v1.17.2, you should use "
-                                           "mruby_output_body_filter{,_code} for response body, or use "
-                                           "mruby_output_header_filter{,_code} for response headers.");
+  ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                     "mruby_output_filter{,_code} was deleted from v1.17.2, you should use "
+                     "mruby_output_body_filter{,_code} for response body, or use "
+                     "mruby_output_header_filter{,_code} for response headers.");
   return NGX_CONF_ERROR;
 }
 
@@ -1405,7 +1410,6 @@ static char *ngx_http_mruby_header_filter_inline(ngx_conf_t *cf, ngx_command_t *
 #if defined(NDK) && NDK
 static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *conf, code_type_t type)
 {
-  ngx_str_t target;
   ngx_str_t *value;
   ndk_set_var_t filter;
   ngx_http_mruby_set_var_data_t *filter_data;
@@ -1418,7 +1422,6 @@ static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *
   mlcf->state = mmcf->state;
 
   value = cf->args->elts;
-  target = value[1];
 
   filter.type = NDK_SET_VAR_MULTI_VALUE_DATA;
   filter.func = cmd->post;
@@ -1429,6 +1432,7 @@ static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *
     return NGX_CONF_ERROR;
   }
 
+  filter_data->target = value[1];
   filter_data->state = mmcf->state;
   filter_data->size = filter.size;
   filter_data->script = value[2];
@@ -1464,7 +1468,7 @@ static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *
   if (filter_data->code == NGX_CONF_UNSET_PTR) {
     if (type == NGX_MRB_CODE_TYPE_FILE) {
       ngx_conf_log_error(NGX_LOG_ERR, cf, 0, "failed to load mruby script: %s %s:%d", filter_data->script.data,
-                         __FUNCTION__, __LINE__, target.data, filter_data->script.data);
+                         __FUNCTION__, __LINE__, filter_data->target.data, filter_data->script.data);
     }
     return NGX_CONF_ERROR;
   }
@@ -1473,9 +1477,9 @@ static char *ngx_http_mruby_set_inner(ngx_conf_t *cf, ngx_command_t *cmd, void *
   *code = filter_data->code;
   filter.data = filter_data;
   ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: target variable=(%s)", MODULE_NAME, __FUNCTION__,
-                     __LINE__, target.data);
+                     __LINE__, filter_data->target.data);
 
-  return ndk_set_var_multi_value_core(cf, &target, &value[3], &filter);
+  return ndk_set_var_multi_value_core(cf, &filter_data->target, &value[3], &filter);
 }
 
 static char *ngx_http_mruby_set(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
@@ -1580,8 +1584,11 @@ static ngx_int_t ngx_http_mruby_set_handler(ngx_http_request_t *r, ngx_str_t *va
 {
   ngx_http_mruby_loc_conf_t *mlcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
   ngx_http_mruby_set_var_data_t *filter_data;
+  ngx_http_mruby_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
 
   filter_data = data;
+
+  ctx->set_var_target = filter_data->target;
 
   if (filter_data->state == NGX_CONF_UNSET_PTR) {
     return NGX_DECLINED;
@@ -1599,7 +1606,10 @@ static ngx_int_t ngx_http_mruby_set_inline_handler(ngx_http_request_t *r, ngx_st
                                                    void *data)
 {
   ngx_http_mruby_set_var_data_t *filter_data;
+  ngx_http_mruby_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
   filter_data = data;
+  ctx->set_var_target = filter_data->target;
+
   ngx_log_error(NGX_LOG_INFO, r->connection->log, 0, "hooked mruby inline set_handler code: %s",
                 filter_data->code->code.string);
   return ngx_mrb_run(r, filter_data->state, filter_data->code, 1, val);

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -51,6 +51,7 @@ typedef struct {
   ngx_str_t script;
   ngx_mrb_state_t *state;
   ngx_mrb_code_t *code;
+  ngx_str_t target;
 } ngx_http_mruby_set_var_data_t;
 #include <ndk.h>
 #endif

--- a/src/http/ngx_http_mruby_request.c
+++ b/src/http/ngx_http_mruby_request.c
@@ -122,8 +122,9 @@ static mrb_value ngx_mrb_read_request_body(mrb_state *mrb, mrb_value self)
   ngx_http_request_t *r = ngx_mrb_get_request();
 
   if (r->method != NGX_HTTP_POST && r->method != NGX_HTTP_PUT) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_mrb_read_request_body can't read"
-                                    " when r->method is neither POST nor PUT");
+    mrb_raise(mrb, E_RUNTIME_ERROR,
+              "ngx_mrb_read_request_body can't read"
+              " when r->method is neither POST nor PUT");
   }
 
   return self;
@@ -135,8 +136,9 @@ static mrb_value ngx_mrb_get_request_body(mrb_state *mrb, mrb_value self)
   ngx_http_request_t *r = ngx_mrb_get_request();
 
   if (r->method != NGX_HTTP_POST && r->method != NGX_HTTP_PUT) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_mrb_read_request_body can't read"
-                                    " when r->method is neither POST nor PUT");
+    mrb_raise(mrb, E_RUNTIME_ERROR,
+              "ngx_mrb_read_request_body can't read"
+              " when r->method is neither POST nor PUT");
   }
 
   return mrb_funcall(mrb, v, "request_body", 0, NULL);
@@ -266,7 +268,7 @@ static ngx_int_t ngx_mrb_set_request_header(mrb_state *mrb, ngx_list_t *headers,
     r->headers_out.server->value.len = val_len;
     break;
 
-  // TODO: Add other built-in headers
+    // TODO: Add other built-in headers
 
   default:
     break;

--- a/src/http/ngx_http_mruby_upstream.c
+++ b/src/http/ngx_http_mruby_upstream.c
@@ -34,7 +34,8 @@ static void ngx_mrb_upstream_context_free(mrb_state *mrb, void *p)
 }
 
 static const struct mrb_data_type ngx_mrb_upstream_context_type = {
-    "ngx_mrb_upstream_context", ngx_mrb_upstream_context_free,
+    "ngx_mrb_upstream_context",
+    ngx_mrb_upstream_context_free,
 };
 
 static mrb_value ngx_mrb_upstream_init(mrb_state *mrb, mrb_value self)

--- a/src/http/ngx_http_mruby_var.c
+++ b/src/http/ngx_http_mruby_var.c
@@ -44,6 +44,11 @@ static mrb_value ngx_mrb_var_get(mrb_state *mrb, mrb_value self, const char *c_n
 
 mrb_value ngx_mrb_var_set(mrb_state *mrb, mrb_value self, char *k, mrb_value o, ngx_http_request_t *r)
 {
+  return ngx_mrb_var_set_vector(mrb, self, k, strlen(k), o, r);
+}
+
+mrb_value ngx_mrb_var_set_vector(mrb_state *mrb, mrb_value self, char *k, int len, mrb_value o, ngx_http_request_t *r)
+{
   ngx_http_variable_t *v;
   ngx_http_variable_value_t *vv;
   ngx_http_core_main_conf_t *cmcf;
@@ -58,7 +63,7 @@ mrb_value ngx_mrb_var_set(mrb_state *mrb, mrb_value self, char *k, mrb_value o, 
 
   val.data = (u_char *)RSTRING_PTR(o);
   val.len = RSTRING_LEN(o);
-  key.len = strlen(k);
+  key.len = len;
   key.data = (u_char *)k;
 
   /* RSTRING_PTR(o) is not always null-terminated */

--- a/src/http/ngx_http_mruby_var.c
+++ b/src/http/ngx_http_mruby_var.c
@@ -42,7 +42,7 @@ static mrb_value ngx_mrb_var_get(mrb_state *mrb, mrb_value self, const char *c_n
   }
 }
 
-static mrb_value ngx_mrb_var_set(mrb_state *mrb, mrb_value self, char *k, mrb_value o, ngx_http_request_t *r)
+mrb_value ngx_mrb_var_set(mrb_state *mrb, mrb_value self, char *k, mrb_value o, ngx_http_request_t *r)
 {
   ngx_http_variable_t *v;
   ngx_http_variable_value_t *vv;

--- a/src/http/ngx_http_mruby_var.h
+++ b/src/http/ngx_http_mruby_var.h
@@ -14,5 +14,5 @@
 #include <mruby/variable.h>
 #include <ngx_http.h>
 
-mrb_value ngx_mrb_var_set(mrb_state *mrb, mrb_value self, char *k, mrb_value o, ngx_http_request_t *r);
+mrb_value ngx_mrb_var_set_vector(mrb_state *mrb, mrb_value self, char *k, int len, mrb_value o, ngx_http_request_t *r);
 #endif // NGX_HTTP_MRUBY_VAR_H

--- a/src/http/ngx_http_mruby_var.h
+++ b/src/http/ngx_http_mruby_var.h
@@ -14,4 +14,5 @@
 #include <mruby/variable.h>
 #include <ngx_http.h>
 
+mrb_value ngx_mrb_var_set(mrb_state *mrb, mrb_value self, char *k, mrb_value o, ngx_http_request_t *r);
 #endif // NGX_HTTP_MRUBY_VAR_H

--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -31,7 +31,8 @@ static void ngx_stream_mrb_upstream_context_free(mrb_state *mrb, void *p)
 }
 
 static const struct mrb_data_type ngx_stream_mrb_upstream_context_type = {
-    "ngx_stream_mrb_upstream_context", ngx_stream_mrb_upstream_context_free,
+    "ngx_stream_mrb_upstream_context",
+    ngx_stream_mrb_upstream_context_free,
 };
 
 static mrb_value ngx_stream_mrb_connection_init(mrb_state *mrb, mrb_value self)

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -401,8 +401,9 @@ static ngx_int_t ngx_stream_mruby_shared_state_compile(ngx_conf_t *cf, mrb_state
     ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: code->code.file=(%s)", MODULE_NAME,
                        __func__, __LINE__, code->code.file);
   } else {
-    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: "
-                                              "code->code.string=(%s)",
+    ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
+                       "%s NOTICE %s:%d: compile info: "
+                       "code->code.string=(%s)",
                        MODULE_NAME, __func__, __LINE__, code->code.string);
   }
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -827,6 +827,19 @@ http {
           proxy_connect_timeout 2s;
         }
 
+        location /sleep_with_proxy_set_code {
+          mruby_set_code $backend '
+            Nginx::Async.sleep 3000
+            backends = [
+              "127.0.0.1:58081",
+              #"test2.example.com",
+              #"test3.example.com",
+            ]
+            backends[rand(backends.length)]
+          ';
+          proxy_pass  http://$backend;
+        }
+
         location /alias_return {
             mruby_rewrite_handler_code '
               Nginx.status_code = 204

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -661,6 +661,12 @@ if nginx_features.is_async_supported?
     t.assert_equal 'proxy test ok', res["body"]
     t.assert_equal 200, res.code
   end
+
+  t.assert('ngx_mruby - Nginx.Async.sleep with proxy(set_code)', 'location /sleep_with_proxy_set_code') do
+    res = HttpRequest.new.get base + '/sleep_with_proxy_set_code'
+    t.assert_equal 'proxy test ok', res["body"]
+    t.assert_equal 200, res.code
+  end
 end
 
 


### PR DESCRIPTION
## Pull-Request Check List
Nginx::Async.sleep利用時に、rewrite_handlerから見るとmrubyのset_codeのrubyコードはsleepを待たずに終了して見えるため、後続の[ngx_http_script_set_var_code](https://github.com/phusion/nginx/blob/master/src/http/ngx_http_script.c#L1666)が空振り実行されてしまい、timer後のmrubyの戻り値が変数に設定されない問題がありました。

このPRでは設定する変数名をコンテキストに記憶しておき、timer後にその変数名に対してmrubyコードの戻り値を設定することで意図した動作になるように変更しています。

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
