### PR TITLE
fix #357 Create ngx_http_mruby_ctx_t if you do not have it

### DIFF
--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -50,10 +50,7 @@ mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RPro
   mrb_value *fiber_proc;
   ngx_http_mruby_ctx_t *ctx;
 
-  ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
-  if (ctx == NULL) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_http_get_module_ctx failed");
-  }
+  ctx = ngx_mrb_http_get_module_ctx(mrb, r);
   ctx->async_handler_result = result;
 
   replace_stop(rproc->body.irep);
@@ -104,7 +101,7 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
   ngx_int_t rc = NGX_OK;
 
   re = ev->data;
-  ctx = ngx_http_get_module_ctx(re->r, ngx_http_mruby_module);
+  ctx = ngx_mrb_http_get_module_ctx(NULL, re->r);
 
   if (ctx != NULL) {
     if (re->fiber != NULL) {

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -356,11 +356,12 @@ ngx_http_mruby_ctx_t *ngx_mrb_http_get_module_ctx(mrb_state *mrb, ngx_http_reque
   ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
   if (ctx == NULL) {
     if ((ctx = ngx_pcalloc(r->pool, sizeof(*ctx))) == NULL) {
-      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "failed to allocate memory from r->pool %s:%d", __FUNCTION__,
-                    __LINE__);
       if (mrb != NULL) {
         mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate context");
       } else {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "failed to allocate memory from r->pool(mrb_state is a nonexistent directive) %s:%d",
+                      __FUNCTION__, __LINE__);
         return NULL;
       }
     }

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -131,11 +131,8 @@ static mrb_value ngx_mrb_send_header(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "i", &status);
   r->headers_out.status = status;
 
-  ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
-  if (ctx == NULL) {
-    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "%s ERROR %s: get mruby context failed.", MODULE_NAME, __func__);
-    mrb_raise(mrb, E_RUNTIME_ERROR, "get mruby context failed");
-  }
+  ctx = ngx_mrb_http_get_module_ctx(mrb, r);
+
   chain = ctx->rputs_chain;
   if (chain) {
     (*chain->last)->buf->last_buf = 1;
@@ -159,11 +156,12 @@ static mrb_value ngx_mrb_rputs_inner(mrb_state *mrb, mrb_value self, int with_lf
   mrb_value argv;
   ngx_buf_t *b;
   ngx_mrb_rputs_chain_list_t *chain;
+  ngx_http_mruby_ctx_t *ctx;
   u_char *str;
   ngx_str_t ns;
 
   ngx_http_request_t *r = ngx_mrb_get_request();
-  ngx_http_mruby_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
+  ctx = ngx_mrb_http_get_module_ctx(mrb, r);
 
   mrb_get_args(mrb, "o", &argv);
 
@@ -350,6 +348,27 @@ static mrb_value ngx_mrb_redirect(mrb_state *mrb, mrb_value self)
   }
 
   return self;
+}
+
+
+
+ngx_http_mruby_ctx_t *ngx_mrb_http_get_module_ctx(mrb_state *mrb, ngx_http_request_t *r) {
+  ngx_http_mruby_ctx_t *ctx;
+  ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
+  if (ctx == NULL) {
+    if ((ctx = ngx_pcalloc(r->pool, sizeof(*ctx))) == NULL) {
+      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "failed to allocate memory from r->pool %s:%d", __FUNCTION__,
+                    __LINE__);
+      if(mrb != NULL) {
+        mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate context");
+      } else {
+        return NULL;
+      }
+    }
+    ctx->body = NULL;
+    ngx_http_set_ctx(r, ctx, ngx_http_mruby_module);
+  }
+  return ctx;
 }
 
 mrb_value ngx_mrb_f_global_remove(mrb_state *mrb, mrb_value self)

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -350,16 +350,15 @@ static mrb_value ngx_mrb_redirect(mrb_state *mrb, mrb_value self)
   return self;
 }
 
-
-
-ngx_http_mruby_ctx_t *ngx_mrb_http_get_module_ctx(mrb_state *mrb, ngx_http_request_t *r) {
+ngx_http_mruby_ctx_t *ngx_mrb_http_get_module_ctx(mrb_state *mrb, ngx_http_request_t *r)
+{
   ngx_http_mruby_ctx_t *ctx;
   ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
   if (ctx == NULL) {
     if ((ctx = ngx_pcalloc(r->pool, sizeof(*ctx))) == NULL) {
       ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "failed to allocate memory from r->pool %s:%d", __FUNCTION__,
                     __LINE__);
-      if(mrb != NULL) {
+      if (mrb != NULL) {
         mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate context");
       } else {
         return NULL;

--- a/src/http/ngx_http_mruby_core.h
+++ b/src/http/ngx_http_mruby_core.h
@@ -40,5 +40,6 @@ void ngx_mrb_raise_cycle_error(mrb_state *mrb, mrb_value obj, ngx_cycle_t *cycle
 void ngx_mrb_raise_conf_error(mrb_state *mrb, mrb_value obj, ngx_conf_t *cf);
 
 ngx_int_t ngx_mrb_finalize_rputs(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ctx);
+ngx_http_mruby_ctx_t *ngx_mrb_http_get_module_ctx(mrb_state *mrb, ngx_http_request_t *r);
 
 #endif // NGX_HTTP_MRUBY_CORE_H

--- a/src/http/ngx_http_mruby_filter.c
+++ b/src/http/ngx_http_mruby_filter.c
@@ -7,6 +7,7 @@
 #include "ngx_http_mruby_filter.h"
 #include "ngx_http_mruby_module.h"
 #include "ngx_http_mruby_request.h"
+#include "ngx_http_mruby_core.h"
 
 #include <mruby.h>
 #include <mruby/class.h>
@@ -18,7 +19,7 @@
 static mrb_value ngx_mrb_get_filter_body(mrb_state *mrb, mrb_value self)
 {
   ngx_http_request_t *r = ngx_mrb_get_request();
-  ngx_http_mruby_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
+  ngx_http_mruby_ctx_t *ctx = ngx_mrb_http_get_module_ctx(mrb, r);
 
   return mrb_str_new(mrb, (char *)ctx->body, ctx->body_length);
 }
@@ -26,7 +27,7 @@ static mrb_value ngx_mrb_get_filter_body(mrb_state *mrb, mrb_value self)
 static mrb_value ngx_mrb_set_filter_body(mrb_state *mrb, mrb_value self)
 {
   ngx_http_request_t *r = ngx_mrb_get_request();
-  ngx_http_mruby_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
+  ngx_http_mruby_ctx_t *ctx = ngx_mrb_http_get_module_ctx(mrb, r);
   mrb_value body;
 
   mrb_get_args(mrb, "o", &body);

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -766,7 +766,7 @@ void ngx_http_mruby_read_request_body_cb(ngx_http_request_t *r)
 {
   ngx_http_mruby_ctx_t *ctx = ngx_mrb_http_get_module_ctx(NULL, r);
 
-  if(ctx != NULL) {
+  if (ctx != NULL) {
     ctx->read_request_body_done = 1;
 
 #if defined(nginx_version) && nginx_version >= 8011
@@ -794,10 +794,10 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_mrb_cod
   }
 
   ctx = ngx_mrb_http_get_module_ctx(NULL, r);
-  if(ctx == NULL) {
-      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "failed to allocate memory context %s:%d", __FUNCTION__,
-                    __LINE__);
-      return NGX_ERROR;
+  if (ctx == NULL) {
+    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "failed to allocate memory context %s:%d", __FUNCTION__,
+                  __LINE__);
+    return NGX_ERROR;
   }
 
   ngx_mrb_push_request(r);


### PR DESCRIPTION
## Pull-Request Check List

refs: https://github.com/matsumotory/ngx_mruby/issues/357

`ngx_http_mruby_ctx_t` がnull状態になる実装箇所があったため、 `ngx_mrb_http_get_module_ctx` メソッドを定義し、get時に値が無ければallocate + setする実装を追加しました。

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
