### PR TITLE
 ngx_mrb_var_set_vector is not executed when fiber is raise

### DIFF
--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -121,9 +121,7 @@ static void ngx_mrb_timer_handler(ngx_event_t *ev)
       if (re->mrb->exc) {
         ngx_mrb_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->r);
         rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
-      }
-
-      if (ctx->set_var_target.len > 1) {
+      } else if (ctx->set_var_target.len > 1) {
         if (ctx->set_var_target.data[0] != '$') {
           ngx_log_error(NGX_LOG_NOTICE, re->r->connection->log, 0,
                         "%s NOTICE %s:%d: invalid variable name error name: %s", MODULE_NAME, __func__, __LINE__,

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -785,7 +785,7 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state, ngx_mrb_cod
 {
   int result_len;
   int ai = 0;
-  mrb_value mrb_result;
+  mrb_value mrb_result = mrb_nil_value();
   ngx_http_mruby_ctx_t *ctx;
   ngx_http_mruby_loc_conf_t *mlcf = ngx_http_get_module_loc_conf(r, ngx_http_mruby_module);
 


### PR DESCRIPTION
## Pull-Request Check List
fiberがraiseした時でも `ngx_mrb_var_set_vector` を実行する分岐になっていたため、不正な値が渡ってくるバグが有りました。

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
