### PR TITLE
Fix cross fiber boundary problem between C and Ruby

### DIFF
--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -44,7 +44,21 @@ class Nginx
   end
 
   class Async
+    class << self
+      def sleep(*args)
+        __sleep(*args)
+        Fiber.yield
+      end
+    end
+
     class HTTP
+      class << self
+        def sub_request(*args)
+          __sub_request(*args)
+          Fiber.yield
+        end
+      end
+
       class Response
         attr_reader :body, :headers, :status
       end


### PR DESCRIPTION
There is a mruby specification that mruby does not cross the fiber boundary between C and Ruby. Since current implementation is an undefined behavior, so we need to rewrite it to appropriate behavior for the specification. 