### PR TITLE
Fix bug; don't run mruby body filter when read upstream buffer completely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,19 @@ install:
   - $CXX -v
 env:
   - NGINX_SRC_MAJOR=1
-    NGINX_SRC_MINOR=12
-    NGINX_SRC_PATCH=2
+    NGINX_SRC_MINOR=14
+    NGINX_SRC_PATCH=0
   - BUILD_DYNAMIC_MODULE='TRUE'
     NGINX_SRC_MAJOR=1
-    NGINX_SRC_MINOR=12
-    NGINX_SRC_PATCH=2
+    NGINX_SRC_MINOR=14
+    NGINX_SRC_PATCH=0
   - NGINX_SRC_MAJOR=1
     NGINX_SRC_MINOR=13
-    NGINX_SRC_PATCH=11
+    NGINX_SRC_PATCH=12
   - BUILD_DYNAMIC_MODULE='TRUE'
     NGINX_SRC_MAJOR=1
     NGINX_SRC_MINOR=13
-    NGINX_SRC_PATCH=11
+    NGINX_SRC_PATCH=12
 
 before_script:
   - curl -sfL https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz -o openssl-1.0.2.tar.gz

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -268,7 +268,8 @@ static ngx_int_t ngx_mrb_async_http_sub_request_done(ngx_http_request_t *sr, voi
     return NGX_ERROR;
   }
 
-  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, sr->parent->connection->log, 0, "http_sub_request done s:%ui", sr->parent->headers_out.status);
+  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, sr->parent->connection->log, 0, "http_sub_request done s:%ui",
+                 sr->parent->headers_out.status);
   ctx->sub_response_more = 0;
 
   return ngx_mrb_post_fiber(re, ctx);
@@ -317,13 +318,13 @@ static mrb_value ngx_mrb_async_http_sub_request(mrb_state *mrb, mrb_value self)
     ngx_memcpy(args->data, RSTRING_PTR(query_params), args->len);
   }
 
-  re = (ngx_mrb_reentrant_t *) ngx_palloc(r->pool, sizeof(ngx_mrb_reentrant_t));
+  re = (ngx_mrb_reentrant_t *)ngx_palloc(r->pool, sizeof(ngx_mrb_reentrant_t));
   re->mrb = mrb;
   re->fiber = (mrb_value *)mrb->ud;
 
   mrb_gc_register(mrb, *re->fiber);
 
-  actx = (ngx_mrb_async_http_ctx_t *) ngx_palloc(r->pool, sizeof(ngx_mrb_async_http_ctx_t));
+  actx = (ngx_mrb_async_http_ctx_t *)ngx_palloc(r->pool, sizeof(ngx_mrb_async_http_ctx_t));
   actx->uri = uri;
   actx->re = re;
 

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -121,6 +121,9 @@ static void ngx_http_mrb_read_subrequest_responce(ngx_http_request_t *r, ngx_htt
   ngx_http_mruby_ctx_t *main_ctx;
   main_ctx = ngx_mrb_http_get_module_ctx(NULL, r->main);
 
+  ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s DEBUG %s:%d: r->main parse subrequest response", MODULE_NAME,
+                __func__, __LINE__);
+
   if (main_ctx != NULL && ctx->body_length > 0) {
     main_ctx->sub_response_body = ngx_palloc(r->pool, ctx->body_length);
     ngx_memcpy(main_ctx->sub_response_body, ctx->body, ctx->body_length);

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -1852,6 +1852,11 @@ static ngx_int_t ngx_http_mruby_read_body(ngx_http_request_t *r, ngx_chain_t *in
 
       return NGX_OK;
     }
+    if (r->upstream && size == rest) {
+      ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0,
+                    "%s DEBUG %s:%d: is not last buffer, but upstream buffer reached", MODULE_NAME, __func__, __LINE__);
+      return NGX_OK;
+    }
   }
 
   ctx->last = p;

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -814,6 +814,8 @@ http {
         }
 
         location /sub_req_proxy_pass {
+            # if subreqeust_in_memory limit reached(default 4k/8k),
+            # increased the memory size by subrequest_output_buffer_size 
             proxy_pass http://127.0.0.1:58081/;
             mruby_output_body_filter_code '
               Nginx.log Nginx::LOG_INFO, "read subrequest proxy pass"

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -813,6 +813,21 @@ http {
             ';
         }
 
+        location /sub_req_proxy_pass {
+            proxy_pass http://127.0.0.1:58081/;
+            mruby_output_body_filter_code '
+              Nginx.log Nginx::LOG_INFO, "read subrequest proxy pass"
+            ';
+        }
+
+        location /async_http_sub_request_with_proxy_pass {
+            mruby_rewrite_handler_code '
+              Nginx::Async::HTTP.sub_request "/sub_req_proxy_pass"
+              res = Nginx::Async::HTTP.last_response
+              Nginx.rputs res.body
+            ';
+        }
+
         location /sub_req_dst {
             mruby_content_handler_code '
               Nginx.rputs Nginx::Request.new.uri_args.inspect

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -656,6 +656,12 @@ if nginx_features.is_async_supported?
     t.assert_equal 200, res.code
   end
 
+  t.assert('ngx_mruby - Nginx::Async::HTTP.new sub request with proxy', 'location /async_http_sub_request_with_proxy_pass') do
+    res = HttpRequest.new.get base + '/async_http_sub_request_with_proxy_pass'
+    t.assert_equal 200, res["code"]
+    t.assert_equal 'proxy test ok', res["body"]
+  end
+
   t.assert('ngx_mruby - Nginx::Async::HTTP.new "/dst"', 'location /async_http_sub_request') do
     res = HttpRequest.new.get base + '/async_http_sub_request'
     t.assert_equal 200, res["code"]


### PR DESCRIPTION
## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).

ngx_mruby is waiting for a long time when ngx_mruby request other location which use proxy_pass using `sub_request` method.