### PR TITLE
Support to get client tls version

### DIFF
--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -276,24 +276,31 @@ alias of Nginx::SSL.errlogger
 #### Nginx::SSL#local_port
 
 ```nginx
+
+mruby_ssl_handshake_handler_code '
+  ssl = Nginx::SSL.new
+  ssl.certificate = "__NGXDOCROOT__/#{ssl.servername}.crt"
+  ssl.certificate_key = "__NGXDOCROOT__/#{ssl.servername}.key"
+  Userdata.new.ssl_local_port = ssl.local_port
+';
+
 location /local_port {
-     mruby_content_handler_code "Nginx.rputs Nginx::SSL.new.local_port.to_s";
+     mruby_content_handler_code "Nginx.rputs Userdata.new.ssl_local_port.to_s";
 }
-```
-
-```
-t.assert('ngx_mruby - ssl local port') do
-  res = `curl -k #{base_ssl(58082) + '/local_port'}`
-  t.assert_equal '58082', res
-end
-
 ```
 
 #### Nginx::SSL#tls_version
 
 ```nginx
-location /tls_version{
-     mruby_content_handler_code "Nginx.rputs Nginx::SSL.new.tls_version.to_s";
+mruby_ssl_handshake_handler_code '
+  ssl = Nginx::SSL.new
+  ssl.certificate = "__NGXDOCROOT__/#{ssl.servername}.crt"
+  ssl.certificate_key = "__NGXDOCROOT__/#{ssl.servername}.key"
+  Userdata.new.ssl_tls_version = ssl.tls_version
+';
+
+location /tls_version {
+    mruby_content_handler_code "Nginx.rputs Userdata.new.ssl_tls_version.to_s";
 }
 ```
 

--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -299,9 +299,12 @@ mruby_ssl_handshake_handler_code '
   Userdata.new.ssl_tls_version = ssl.tls_version
 ';
 
+# The return value is the value of SSL_get_version.
+# refs: https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html
 location /tls_version {
     mruby_content_handler_code "Nginx.rputs Userdata.new.ssl_tls_version.to_s";
 }
+
 ```
 
 ## Nginx::Request Class

--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -289,6 +289,14 @@ end
 
 ```
 
+#### Nginx::SSL#tls_version
+
+```nginx
+location /tls_version{
+     mruby_content_handler_code "Nginx.rputs Nginx::SSL.new.tls_version.to_s";
+}
+```
+
 ## Nginx::Request Class
 ### Method
 #### Nginx::Request#scheme

--- a/src/http/ngx_http_mruby_ssl.c
+++ b/src/http/ngx_http_mruby_ssl.c
@@ -147,7 +147,7 @@ static mrb_value ngx_mrb_ssl_local_port(mrb_state *mrb, mrb_value self)
 
 static mrb_value ngx_mrb_ssl_tls_version(mrb_state *mrb, mrb_value self)
 {
-  mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_mrb_ssl_ssl_tls_version doesn't support");
+  mrb_raise(mrb, E_RUNTIME_ERROR, "ngx_mrb_ssl_tls_version doesn't support");
 }
 
 #endif /* OPENSSL_VERSION_NUMBER >= 0x1000205fL */

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -57,10 +57,15 @@ http {
           ssl.certificate = "__NGXDOCROOT__/#{ssl.servername}.crt"
           ssl.certificate_key = "__NGXDOCROOT__/#{ssl.servername}.key"
           Userdata.new.ssl_local_port = ssl.local_port
+          Userdata.new.ssl_tls_version = ssl.tls_version
         ';
 
         location /local_port {
             mruby_content_handler_code "Nginx.rputs Userdata.new.ssl_local_port.to_s";
+        }
+
+        location /tls_version {
+            mruby_content_handler_code "Nginx.rputs Userdata.new.ssl_tls_version.to_s";
         }
 
         location / {

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -534,6 +534,12 @@ t.assert('ngx_mruby - get ssl server name') do
   t.assert_equal "ngx.example.com", res.chomp
 end
 
+t.assert('ngx_mruby - get ssl tls version') do
+  res = `curl -s -k #{base_ssl(58082) + '/tls_version'}`
+
+  t.assert_equal "TLSv1.2", res.chomp
+end
+
 t.assert('ngx_mruby - issue_172', 'location /issue_172') do
   res = HttpRequest.new.get base + '/issue_172/index.html'
   expect_content = 'hello world'.upcase


### PR DESCRIPTION
## Pull-Request Check List
hi! ry sann!

SSLハンドシェーク中にTLSのバージョンを取得できるようにしました。これによって古いクライアントからの接続要求時に処理を分岐するなどの実装が可能になります。

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
