### PR TITLE
Base Docker Image Update Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Dockerfile for ngx_mruby on ubuntu 14.04 64bit
+# Dockerfile for ngx_mruby on ubuntu 18.04 64bit
 #
 
 #
@@ -28,7 +28,7 @@
 #   curl http://127.0.0.1:10080/mruby-hello
 #
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 MAINTAINER matsumotory
 
 RUN apt-get -y update
@@ -36,9 +36,9 @@ RUN apt-get -y install sudo openssh-server
 RUN apt-get -y install git
 RUN apt-get -y install curl
 RUN apt-get -y install rake
-RUN apt-get -y install ruby2.0 ruby2.0-dev
+RUN apt-get -y install ruby ruby-dev
 RUN apt-get -y install bison
-RUN apt-get -y install libcurl4-openssl-dev
+RUN apt-get -y install libcurl4-openssl-dev libssl-dev
 RUN apt-get -y install libhiredis-dev
 RUN apt-get -y install libmarkdown2-dev
 RUN apt-get -y install libcap-dev
@@ -46,6 +46,7 @@ RUN apt-get -y install libcgroup-dev
 RUN apt-get -y install make
 RUN apt-get -y install libpcre3 libpcre3-dev
 RUN apt-get -y install libmysqlclient-dev
+RUN apt-get -y install gcc
 
 RUN cd /usr/local/src/ && git clone https://github.com/matsumotory/ngx_mruby.git
 ENV NGINX_CONFIG_OPT_ENV --with-http_stub_status_module --with-http_ssl_module --prefix=/usr/local/nginx --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module


### PR DESCRIPTION
## description
- The base Docker image is old, so I update it.
- Because, of the version of open-ssl even if you build nginx.conf containing SSL related configure, it will cause an error 
  - Should we PR code that solves the openssl problem without update the base image version?

### Dockerfile
```
FROM matsumotory/ngx-mruby:latest
```

### nginx.conf
```
user daemon;
daemon off;
master_process off;
worker_processes auto;
error_log stderr;

events {
    worker_connections 1024;
}

http {
    include mime.types;

    mruby_init_worker_code '
        Userdata.new.redis = Redis.new "redis", 6379
    ';

    server {
        listen 80;
        server_name _;

        location / {
            mruby_content_handler_code 'Nginx.rputs "hello #{Nginx::Request.new.hostname} world!"';
        }
    }

    server {
        listen 443 ssl;
        server_name  _;
        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
        ssl_ciphers HIGH:!aNULL:!MD5;
        ssl_certificate /usr/local/nginx/conf/dummy.crt;
        ssl_certificate_key /usr/local/nginx/conf/dummy.key;

        mruby_ssl_handshake_handler_code '
          ssl = Nginx::SSL.new
          domain = ssl.servername
          redis = Userdata.new.redis
          ssl.certificate_data = redis["#{domain}.crt"]
          ssl.certificate_key_data = redis["#{domain}.key"]
        ';

        location / {
            mruby_content_handler_code 'Nginx.rputs "hello #{Nginx::Request.new.hostname} world!"';
        }
    }
}

```


### logs
```
$ docker build -t local/ngx_mruby .
Sending build context to Docker daemon  115.7kB
Step 1/1 : FROM matsumotory/ngx-mruby:latest
# Executing 3 build triggers
 ---> 08b500f89169
Successfully built 08b500f89169
Successfully tagged local/ngx_mruby:latest
$ docker run -p 8080:80 local/ngx_mruby
nginx: [emerg] ngx_mruby : OpenSSL 1.0.2e or later required but found OpenSSL 1.0.1f 6 Jan 2014
```

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
