### PR TITLE
Remove deprecated property

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -4,7 +4,6 @@ Please see [example repository](https://github.com/matsumotory/docker-ngx_mruby)
 #### 1. Create Dockerfile
 ```
 FROM matsumotory/ngx-mruby:latest
-MAINTAINER matsumotory
 ```
 #### 2. Create docker directory
 which was included hook files and nginx.conf in same directory as Dockerfile. like [this](https://github.com/matsumoto-r/ngx_mruby/tree/master/docker)


### PR DESCRIPTION
## About

FYI: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
MAINTAINER property is deprecated

## Pull-Request Check List

- [-] Add patches into `src/`.
- [-] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [-] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
