### PR TITLE
Print generated code for debug if NGX_MRUBY_IREP_DEBUG is defined.

### DIFF
--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -988,8 +988,6 @@ static ngx_int_t ngx_http_mruby_shared_state_init(ngx_mrb_state_t *state)
   return NGX_OK;
 }
 
-#define NGX_MRUBY_IREP_DEBUG
-
 static ngx_int_t ngx_http_mruby_shared_state_compile(ngx_conf_t *cf, ngx_mrb_state_t *state, ngx_mrb_code_t *code)
 {
   FILE *mrb_file;

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -988,23 +988,27 @@ static ngx_int_t ngx_http_mruby_shared_state_init(ngx_mrb_state_t *state)
   return NGX_OK;
 }
 
+#define NGX_MRUBY_IREP_DEBUG
+
 static ngx_int_t ngx_http_mruby_shared_state_compile(ngx_conf_t *cf, ngx_mrb_state_t *state, ngx_mrb_code_t *code)
 {
   FILE *mrb_file;
   struct mrb_parser_state *p;
 
+  NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
+  code->ctx = mrbc_context_new(state->mrb);
+#ifdef NGX_MRUBY_IREP_DEBUG
+  code->ctx->dump_result = TRUE;
+#endif
+ 
   if (code->code_type == NGX_MRB_CODE_TYPE_FILE) {
     if ((mrb_file = fopen((char *)code->code.file, "r")) == NULL) {
       return NGX_ERROR;
     }
-    NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
-    code->ctx = mrbc_context_new(state->mrb);
     mrbc_filename(state->mrb, code->ctx, (char *)code->code.file);
     p = mrb_parse_file(state->mrb, mrb_file, code->ctx);
     fclose(mrb_file);
   } else {
-    NGX_MRUBY_CODE_MRBC_CONTEXT_FREE(state->mrb, code);
-    code->ctx = mrbc_context_new(state->mrb);
     mrbc_filename(state->mrb, code->ctx, "INLINE CODE");
     p = mrb_parse_string(state->mrb, (char *)code->code.string, code->ctx);
   }
@@ -1018,6 +1022,12 @@ static ngx_int_t ngx_http_mruby_shared_state_compile(ngx_conf_t *cf, ngx_mrb_sta
   if (code->proc == NULL) {
     return NGX_ERROR;
   }
+
+#ifdef NGX_MRUBY_IREP_DEBUG
+  /* mrb_codedump_all() is not declared in mruby headers. So just follows the mruby way. See mruby/src/load.c. */
+  void mrb_codedump_all(mrb_state*, struct RProc*);
+  mrb_codedump_all(state->mrb, code->proc);
+#endif
 
   if (code->code_type == NGX_MRB_CODE_TYPE_FILE) {
     ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0, "%s NOTICE %s:%d: compile info: code->code.file=(%s) code->cache=(%d)",


### PR DESCRIPTION
With -DNGX_MRUBY_IREP_DEBUG, you will see the following generated code information for debug.

```
00001 NODE_SCOPE:
00001   NODE_BEGIN:
00001     NODE_CALL(.):
00001       NODE_CONST Nginx
00001       method='return' (1460)
00001       args:
00001         NODE_COLON2:
00001           NODE_CONST Nginx
00001           ::OK
irep 0xfd9f90 nregs=4 nlocals=1 pools=0 syms=3 reps=0
file: INLINE CODE
    1 000 OP_GETCONST	R1	:Nginx
    1 003 OP_GETCONST	R2	:Nginx
    1 006 OP_GETMCNST	R2	R2::OK
    1 009 OP_SEND	R1	:return	1
    1 013 OP_RETURN	R1		
    1 015 OP_STOP

00002 NODE_SCOPE:
00002   NODE_BEGIN:
00002     NODE_CALL(.):
00002       NODE_CONST Nginx
00002       method='rputs' (1462)
00002       args:
00002         NODE_STR "OK" len 2
00003     NODE_CALL(.):
00003       NODE_CONST Nginx
00003       method='return' (1460)
00003       args:
00003         NODE_INT 200 base 10
irep 0xfda0f0 nregs=4 nlocals=1 pools=1 syms=3 reps=0
file: INLINE CODE
    2 000 OP_GETCONST	R1	:Nginx
    2 003 OP_STRING	R2	L(0)	; "OK"
    2 006 OP_SEND	R1	:rputs	1
    3 010 OP_GETCONST	R1	:Nginx
    3 013 OP_LOADI	R2	200	
    3 016 OP_SEND	R1	:return	1
    3 020 OP_RETURN	R1		
    3 022 OP_STOP
```

## Pull-Request Check List

- [x ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
