### PR TITLE
Refactoring

### DIFF
--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -8,8 +8,12 @@ class Nginx
       Nginx::Server.new.document_root
     end
 
+    def read_body
+      # NOP. Just for backward compatibility.
+      Nginx::OK
+    end
+
     def body
-      self.read_body
       self.get_body
     end
 

--- a/src/http/ngx_http_mruby_request.c
+++ b/src/http/ngx_http_mruby_request.c
@@ -115,20 +115,6 @@ NGX_MRUBY_DEFINE_METHOD_NGX_GET_REQUEST_HEADERS_HASH(out);
 NGX_MRUBY_DEFINE_METHOD_NGX_GET_REQUEST_MEMBER_STR(content_type, r->headers_out.content_type);
 NGX_MRUBY_DEFINE_METHOD_NGX_SET_REQUEST_MEMBER_STR(content_type, r->headers_out.content_type);
 
-/* Methods that are no longer needed via issue-268 */
-static mrb_value ngx_mrb_read_request_body(mrb_state *mrb, mrb_value self)
-{
-  ngx_http_request_t *r = ngx_mrb_get_request();
-
-  if (r->method != NGX_HTTP_POST && r->method != NGX_HTTP_PUT) {
-    mrb_raise(mrb, E_RUNTIME_ERROR,
-              "ngx_mrb_read_request_body can't read"
-              " when r->method is neither POST nor PUT");
-  }
-
-  return self;
-}
-
 static mrb_value ngx_mrb_get_request_body(mrb_state *mrb, mrb_value self)
 {
   mrb_value v = ngx_mrb_get_request_var(mrb, self);
@@ -602,7 +588,6 @@ void ngx_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
 
   class_request = mrb_define_class_under(mrb, class, "Request", mrb->object_class);
   mrb_define_method(mrb, class_request, "get_body", ngx_mrb_get_request_body, MRB_ARGS_NONE());
-  mrb_define_method(mrb, class_request, "read_body", ngx_mrb_read_request_body, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_request, "content_type=", ngx_mrb_set_content_type, MRB_ARGS_ANY());
   mrb_define_method(mrb, class_request, "content_type", ngx_mrb_get_content_type, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_request, "request_line", ngx_mrb_get_request_request_line, MRB_ARGS_NONE());

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -2,15 +2,6 @@
 # ngx_mruby test
 #
 
-# Temporary solution for https://github.com/iij/mruby-io/issues/75
-begin
-  `/bin/true`
-rescue NotImplementedError => e
-  module Kernel
-    def `(c); IO.popen(c) { |io| io.read }; end
-  end
-end
-
 def http_host(port = 58080)
   "127.0.0.1:#{port}"
 end


### PR DESCRIPTION
* Remove temporary solution for https://github.com/iij/mruby-io/issues/75 that was fixed in Apr 2017.
* Move read_body to mrb_nginx.rb from ngx_http_mruby_request.c to reduce C code size. The method (in C, ngx_mrb_read_request_body) does nothing after #269.

## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
