### PR TITLE
Upgrade mruby to 2.0.0

### DIFF
--- a/mruby/README.md
+++ b/mruby/README.md
@@ -17,7 +17,7 @@ of the Ministry of Economy, Trade and Industry of Japan.
 
 ## How to get mruby
 
-The stable version 1.4.1 of mruby can be downloaded via the following URL: [https://github.com/mruby/mruby/archive/1.4.1.zip](https://github.com/mruby/mruby/archive/1.4.1.zip)
+The stable version 2.0.0 of mruby can be downloaded via the following URL: [https://github.com/mruby/mruby/archive/2.0.0.zip](https://github.com/mruby/mruby/archive/2.0.0.zip)
 
 The latest development version of mruby can be downloaded via the following URL: [https://github.com/mruby/mruby/zipball/master](https://github.com/mruby/mruby/zipball/master)
 

--- a/mruby/doc/guides/debugger.md
+++ b/mruby/doc/guides/debugger.md
@@ -38,7 +38,7 @@ To confirm mrdb was installed properly, run mrdb with the `--version` option:
 
 ```bash
 $ mrdb --version
-mruby 1.4.1 (2018-4-27)
+mruby 2.0.0 (2018-12-11)
 ```
 
 ## 2.2 Basic Operation

--- a/mruby/doc/limitations.md
+++ b/mruby/doc/limitations.md
@@ -38,7 +38,7 @@ puts [1,2,3]
 3
 ```
 
-#### mruby [1.4.1 (2018-4-27)]
+#### mruby [2.0.0 (2018-12-11)]
 
 ```
 [1, 2, 3]
@@ -61,7 +61,7 @@ end
 
 ```ZeroDivisionError``` is raised.
 
-#### mruby [1.4.1 (2018-4-27)]
+#### mruby [2.0.0 (2018-12-11)]
 
 No exception is raised.
 
@@ -119,7 +119,7 @@ false
 true
 ```
 
-#### mruby [1.4.1 (2018-4-27)]
+#### mruby [2.0.0 (2018-12-11)]
 
 ```
 true
@@ -142,7 +142,7 @@ defined?(Foo)
 nil
 ```
 
-#### mruby [1.4.1 (2018-4-27)]
+#### mruby [2.0.0 (2018-12-11)]
 
 ```NameError``` is raised.
 
@@ -159,7 +159,7 @@ alias $a $__a__
 
 ``` nil ```
 
-#### mruby [1.4.1 (2018-4-27)]
+#### mruby [2.0.0 (2018-12-11)]
 
 Syntax error
 
@@ -181,7 +181,7 @@ end
 ```ArgumentError``` is raised.
 The re-defined ```+``` operator does not accept any arguments.
 
-#### mruby [1.4.1 (2018-4-27)]
+#### mruby [2.0.0 (2018-12-11)]
 
 ``` 'ab' ```
 Behavior of the operator wasn't changed.
@@ -197,7 +197,7 @@ $ ruby -e 'puts Proc.new {}.binding'
 #<Binding:0x00000e9deabb9950>
 ```
 
-#### mruby [1.4.1 (2018-4-27)]
+#### mruby [2.0.0 (2018-12-11)]
 
 ```
 $ ./bin/mruby -e 'puts Proc.new {}.binding'
@@ -219,7 +219,7 @@ $ ruby -e 'def m(*r,**k) p [r,k] end; m("a"=>1,:b=>2)'
 [[{"a"=>1}], {:b=>2}]
 ```
 
-#### mruby []
+#### mruby [mruby 2.0.0]
 
 ```
 $ ./bin/mruby -e 'def m(*r,**k) p [r,k] end; m("a"=>1,:b=>2)'
@@ -227,3 +227,23 @@ trace (most recent call last):
 	[0] -e:1
 -e:1: keyword argument hash with non symbol keys (ArgumentError)
 ```
+
+## Argument Destructuring
+
+```ruby
+def m(a,(b,c),d); p [a,b,c,d]; end
+m(1,[2,3],4)  # => [1,2,3,4]
+```
+Destructured arguments (`b` and `c` in above example) cannot be accessed
+from the default expression of optional arguments and keyword arguments,
+since actual assignment is done after the evaluation of those default
+expressions. Thus:
+    
+```ruby
+def f(a,(b,c),d=b)
+  p [a,b,c,d]
+end
+f(1,[2,3])
+```
+
+CRuby gives `[1,2,3,nil]`. mruby raises `NoMethodError` for `b`.

--- a/mruby/include/mruby.h
+++ b/mruby/include/mruby.h
@@ -267,7 +267,8 @@ typedef struct mrb_state {
 #else
   mrb_atexit_func *atexit_stack;
 #endif
-  mrb_int atexit_stack_len;
+  uint16_t atexit_stack_len;
+  uint16_t ecall_nest;                    /* prevent infinite recursive ecall() */
 } mrb_state;
 
 /**
@@ -716,7 +717,6 @@ MRB_API mrb_value mrb_notimplement_m(mrb_state*, mrb_value);
  * @return [mrb_value] The newly duplicated object.
  */
 MRB_API mrb_value mrb_obj_dup(mrb_state *mrb, mrb_value obj);
-MRB_API mrb_value mrb_check_to_integer(mrb_state *mrb, mrb_value val, const char *method);
 
 /**
  * Returns true if obj responds to the given method. If the method was defined for that
@@ -854,10 +854,6 @@ typedef const char *mrb_args_format;
 
 /**
  * Retrieve arguments from mrb_state.
- *
- * When applicable, implicit conversions (such as `to_str`, `to_ary`, `to_hash`) are
- * applied to received arguments.
- * Used inside a function of mrb_func_t type.
  *
  * @param mrb The current MRuby state.
  * @param format [mrb_args_format] is a list of format specifiers
@@ -1188,6 +1184,7 @@ MRB_API void mrb_gc_unregister(mrb_state *mrb, mrb_value obj);
 
 MRB_API mrb_value mrb_to_int(mrb_state *mrb, mrb_value val);
 #define mrb_int(mrb, val) mrb_fixnum(mrb_to_int(mrb, val))
+MRB_API mrb_value mrb_to_str(mrb_state *mrb, mrb_value val);
 MRB_API void mrb_check_type(mrb_state *mrb, mrb_value x, enum mrb_vtype t);
 
 typedef enum call_type {

--- a/mruby/include/mruby/array.h
+++ b/mruby/include/mruby/array.h
@@ -199,6 +199,7 @@ MRB_API void mrb_ary_set(mrb_state *mrb, mrb_value ary, mrb_int n, mrb_value val
  * @param other The array to replace it with.
  */
 MRB_API void mrb_ary_replace(mrb_state *mrb, mrb_value self, mrb_value other);
+MRB_API mrb_value mrb_ensure_array_type(mrb_state *mrb, mrb_value self);
 MRB_API mrb_value mrb_check_array_type(mrb_state *mrb, mrb_value self);
 
 /*

--- a/mruby/include/mruby/compile.h
+++ b/mruby/include/mruby/compile.h
@@ -143,7 +143,6 @@ struct mrb_parser_state {
   mrb_ast_node *heredocs_from_nextline;
   mrb_ast_node *parsing_heredoc;
   mrb_ast_node *lex_strterm_before_heredoc;
-  mrb_bool heredoc_end_now:1; /* for mirb */
 
   void *ylval;
 
@@ -158,8 +157,8 @@ struct mrb_parser_state {
   struct mrb_parser_message warn_buffer[10];
 
   mrb_sym* filename_table;
-  size_t filename_table_length;
-  int current_filename_index;
+  uint16_t filename_table_length;
+  uint16_t current_filename_index;
 
   struct mrb_jmpbuf* jmp;
 };

--- a/mruby/include/mruby/debug.h
+++ b/mruby/include/mruby/debug.h
@@ -55,10 +55,11 @@ MRB_API const char *mrb_debug_get_filename(mrb_irep *irep, ptrdiff_t pc);
  */
 MRB_API int32_t mrb_debug_get_line(mrb_irep *irep, ptrdiff_t pc);
 
-MRB_API mrb_irep_debug_info_file *mrb_debug_info_append_file(
-    mrb_state *mrb, mrb_irep *irep,
-    uint32_t start_pos, uint32_t end_pos);
 MRB_API mrb_irep_debug_info *mrb_debug_info_alloc(mrb_state *mrb, mrb_irep *irep);
+MRB_API mrb_irep_debug_info_file *mrb_debug_info_append_file(
+    mrb_state *mrb, mrb_irep_debug_info *info,
+    const char *filename, uint16_t *lines,
+    uint32_t start_pos, uint32_t end_pos);
 MRB_API void mrb_debug_info_free(mrb_state *mrb, mrb_irep_debug_info *d);
 
 MRB_END_DECL

--- a/mruby/include/mruby/hash.h
+++ b/mruby/include/mruby/hash.h
@@ -18,7 +18,7 @@ MRB_BEGIN_DECL
 struct RHash {
   MRB_OBJECT_HEADER;
   struct iv_tbl *iv;
-  struct seglist *ht;
+  struct htable *ht;
 };
 
 #define mrb_hash_ptr(v)    ((struct RHash*)(mrb_ptr(v)))

--- a/mruby/include/mruby/irep.h
+++ b/mruby/include/mruby/irep.h
@@ -39,9 +39,6 @@ typedef struct mrb_irep {
 
   struct mrb_locals *lv;
   /* debug info */
-  mrb_bool own_filename;
-  const char *filename;
-  uint16_t *lines;
   struct mrb_irep_debug_info* debug_info;
 
   uint16_t ilen, plen, slen, rlen;
@@ -51,8 +48,13 @@ typedef struct mrb_irep {
 #define MRB_ISEQ_NO_FREE 1
 
 MRB_API mrb_irep *mrb_add_irep(mrb_state *mrb);
+
+/* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep(mrb_state*, const uint8_t*);
+
+/* @param [const uint8_t*] irep code, expected as a literal */
 MRB_API mrb_value mrb_load_irep_cxt(mrb_state*, const uint8_t*, mrbc_context*);
+
 void mrb_irep_free(mrb_state*, struct mrb_irep*);
 void mrb_irep_incref(mrb_state*, struct mrb_irep*);
 void mrb_irep_decref(mrb_state*, struct mrb_irep*);

--- a/mruby/include/mruby/string.h
+++ b/mruby/include/mruby/string.h
@@ -311,9 +311,12 @@ MRB_API mrb_value mrb_str_substr(mrb_state *mrb, mrb_value str, mrb_int beg, mrb
  * @param [mrb_value] str Ruby string.
  * @return [mrb_value] A Ruby string.
  */
+MRB_API mrb_value mrb_ensure_string_type(mrb_state *mrb, mrb_value str);
+MRB_API mrb_value mrb_check_string_type(mrb_state *mrb, mrb_value str);
+/* obsolete: use mrb_ensure_string_type() instead */
 MRB_API mrb_value mrb_string_type(mrb_state *mrb, mrb_value str);
 
-MRB_API mrb_value mrb_check_string_type(mrb_state *mrb, mrb_value str);
+
 MRB_API mrb_value mrb_str_new_capa(mrb_state *mrb, size_t capa);
 MRB_API mrb_value mrb_str_buf_new(mrb_state *mrb, size_t capa);
 
@@ -353,6 +356,7 @@ MRB_API double mrb_str_to_dbl(mrb_state *mrb, mrb_value str, mrb_bool badcheck);
 
 /*
  * Returns a converted string type.
+ * For type checking, non converting `mrb_to_str` is recommended.
  */
 MRB_API mrb_value mrb_str_to_str(mrb_state *mrb, mrb_value str);
 

--- a/mruby/include/mruby/throw.h
+++ b/mruby/include/mruby/throw.h
@@ -15,9 +15,9 @@
 
 #if defined(MRB_ENABLE_CXX_EXCEPTION) && defined(__cplusplus)
 
-#define MRB_TRY(buf) do { try {
+#define MRB_TRY(buf) try {
 #define MRB_CATCH(buf) } catch(mrb_jmpbuf_impl e) { if (e != (buf)->impl) { throw e; }
-#define MRB_END_EXC(buf)  } } while(0)
+#define MRB_END_EXC(buf)  }
 
 #define MRB_THROW(buf) throw((buf)->impl)
 typedef mrb_int mrb_jmpbuf_impl;
@@ -34,9 +34,9 @@ typedef mrb_int mrb_jmpbuf_impl;
 #define MRB_LONGJMP longjmp
 #endif
 
-#define MRB_TRY(buf) do { if (MRB_SETJMP((buf)->impl) == 0) {
+#define MRB_TRY(buf) if (MRB_SETJMP((buf)->impl) == 0) {
 #define MRB_CATCH(buf) } else {
-#define MRB_END_EXC(buf) } } while(0)
+#define MRB_END_EXC(buf) }
 
 #define MRB_THROW(buf) MRB_LONGJMP((buf)->impl, 1);
 #define mrb_jmpbuf_impl jmp_buf

--- a/mruby/include/mruby/version.h
+++ b/mruby/include/mruby/version.h
@@ -27,7 +27,7 @@ MRB_BEGIN_DECL
 /*
  * The version of Ruby used by mruby.
  */
-#define MRUBY_RUBY_VERSION "1.9"
+#define MRUBY_RUBY_VERSION "2.0"
 
 /*
  * Ruby engine.
@@ -37,17 +37,17 @@ MRB_BEGIN_DECL
 /*
  * Major release version number.
  */
-#define MRUBY_RELEASE_MAJOR 1
+#define MRUBY_RELEASE_MAJOR 2
 
 /*
  * Minor release version number.
  */
-#define MRUBY_RELEASE_MINOR 4
+#define MRUBY_RELEASE_MINOR 0
 
 /*
  * Tiny release version number.
  */
-#define MRUBY_RELEASE_TEENY 1
+#define MRUBY_RELEASE_TEENY 0
 
 /*
  * The mruby version.
@@ -67,12 +67,12 @@ MRB_BEGIN_DECL
 /*
  * Release month.
  */
-#define MRUBY_RELEASE_MONTH 4
+#define MRUBY_RELEASE_MONTH 12
 
 /*
  * Release day.
  */
-#define MRUBY_RELEASE_DAY 27
+#define MRUBY_RELEASE_DAY 11
 
 /*
  * Release date as a string.

--- a/mruby/mrbgems/mruby-array-ext/mrblib/array.rb
+++ b/mruby/mrbgems/mruby-array-ext/mrblib/array.rb
@@ -1,30 +1,4 @@
-# coding: cp932
 class Array
-  ##
-  # call-seq:
-  #    Array.try_convert(obj) -> array or nil
-  #
-  # Tries to convert +obj+ into an array, using +to_ary+ method.
-  # converted array or +nil+ if +obj+ cannot be converted for any reason.
-  # This method can be used to check if an argument is an array.
-  #
-  #    Array.try_convert([1])   #=> [1]
-  #    Array.try_convert("1")   #=> nil
-  #
-  #    if tmp = Array.try_convert(arg)
-  #      # the argument is an array
-  #    elsif tmp = String.try_convert(arg)
-  #      # the argument is a string
-  #    end
-  #
-  def self.try_convert(obj)
-    if obj.respond_to?(:to_ary)
-      obj.to_ary
-    else
-      nil
-    end
-  end
-
   ##
   # call-seq:
   #    ary.uniq!                -> ary or nil
@@ -317,7 +291,7 @@ class Array
   #                              #=> "100 is out of bounds"
   #
 
-  def fetch(n=nil, ifnone=NONE, &block)
+  def fetch(n, ifnone=NONE, &block)
     warn "block supersedes default value argument" if !n.nil? && ifnone != NONE && block
 
     idx = n
@@ -799,16 +773,6 @@ class Array
   end
 
   ##
-  #  call-seq:
-  #     ary.to_ary -> ary
-  #
-  #  Returns +self+.
-  #
-  def to_ary
-    self
-  end
-
-  ##
   # call-seq:
   #   ary.dig(idx, ...)                 -> object
   #
@@ -927,7 +891,7 @@ class Array
   #
   # Assumes that self is an array of arrays and transposes the rows and columns.
   #
-  # If the length of the subarrays don’t match, an IndexError is raised.
+  # If the length of the subarrays don't match, an IndexError is raised.
   #
   # Examples:
   #

--- a/mruby/mrbgems/mruby-array-ext/test/array.rb
+++ b/mruby/mrbgems/mruby-array-ext/test/array.rb
@@ -1,13 +1,6 @@
 ##
 # Array(Ext) Test
 
-assert("Array.try_convert") do
-  assert_nil Array.try_convert(0)
-  assert_nil Array.try_convert(nil)
-  assert_equal [], Array.try_convert([])
-  assert_equal [1,2,3], Array.try_convert([1,2,3])
-end
-
 assert("Array#assoc") do
   s1 = [ "colors", "red", "blue", "green" ]
   s2 = [ "letters", "a", "b", "c" ]
@@ -338,25 +331,9 @@ assert('Array#to_h') do
   assert_raise(ArgumentError) { [[1]].to_h }
 end
 
-assert('Array#to_h (Modified)') do
-  class A
-    def to_ary
-      $a.clear
-      nil
-    end
-  end
-  $a = [A.new]
-  assert_raise(TypeError) { $a.to_h }
-end
-
 assert("Array#index (block)") do
   assert_nil (1..10).to_a.index { |i| i % 5 == 0 and i % 7 == 0 }
   assert_equal 34, (1..100).to_a.index { |i| i % 5 == 0 and i % 7 == 0 }
-end
-
-assert("Array#to_ary") do
-  assert_equal [], [].to_ary
-  assert_equal [1,2,3], [1,2,3].to_ary
 end
 
 assert("Array#dig") do

--- a/mruby/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/mruby/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -41,7 +41,7 @@ usage(const char *name)
   "switches:",
   "-b           load and execute RiteBinary (mrb) file",
   "-c           check syntax only",
-  "-d           set debugging flags (set $DEBUG to true)"
+  "-d           set debugging flags (set $DEBUG to true)",
   "-e 'command' one line of script",
   "-r library   load the library before executing your script",
   "-v           print version number, then run in verbose mode",

--- a/mruby/mrbgems/mruby-compiler/core/codegen.c
+++ b/mruby/mrbgems/mruby-compiler/core/codegen.c
@@ -125,15 +125,6 @@ codegen_palloc(codegen_scope *s, size_t len)
 }
 
 static void*
-codegen_malloc(codegen_scope *s, size_t len)
-{
-  void *p = mrb_malloc_simple(s->mrb, len);
-
-  if (!p) codegen_error(s, "mrb_malloc");
-  return p;
-}
-
-static void*
 codegen_realloc(codegen_scope *s, void *p, size_t len)
 {
   p = mrb_realloc_simple(s->mrb, p, len);
@@ -162,11 +153,13 @@ emit_B(codegen_scope *s, uint32_t pc, uint8_t i)
     s->iseq = (mrb_code *)codegen_realloc(s, s->iseq, sizeof(mrb_code)*s->icapa);
     if (s->lines) {
       s->lines = (uint16_t*)codegen_realloc(s, s->lines, sizeof(uint16_t)*s->icapa);
-      s->irep->lines = s->lines;
     }
   }
   if (s->lines) {
-    s->lines[pc] = s->lineno;
+    if (s->lineno > 0 || pc == 0)
+      s->lines[pc] = s->lineno;
+    else
+      s->lines[pc] = s->lines[pc-1];
   }
   s->iseq[pc] = i;
 }
@@ -741,15 +734,13 @@ lambda_body(codegen_scope *s, node *tree, int blk)
     mrb_aspec a;
     int ma, oa, ra, pa, ka, kd, ba;
     int pos, i;
-    node *n, *opt;
+    node *opt;
+    node *margs, *pargs;
     node *tail;
 
     /* mandatory arguments */
     ma = node_len(tree->car->car);
-    n = tree->car->car;
-    while (n) {
-      n = n->cdr;
-    }
+    margs = tree->car->car;
     tail = tree->car->cdr->cdr->cdr->cdr;
 
     /* optional arguments */
@@ -758,6 +749,7 @@ lambda_body(codegen_scope *s, node *tree, int blk)
     ra = tree->car->cdr->cdr->car ? 1 : 0;
     /* mandatory arugments after rest argument */
     pa = node_len(tree->car->cdr->cdr->cdr->car);
+    pargs = tree->car->cdr->cdr->cdr->car;
     /* keyword arguments */
     ka = tail? node_len(tail->cdr->car) : 0;
     /* keyword dictionary? */
@@ -805,6 +797,7 @@ lambda_body(codegen_scope *s, node *tree, int blk)
       dispatch(s, pos+i*3+1);
     }
 
+    /* keyword arguments */
     if (tail) {
       node *kwds = tail->cdr->car;
       int kwrest = 0;
@@ -843,7 +836,34 @@ lambda_body(codegen_scope *s, node *tree, int blk)
         genop_0(s, OP_KEYEND);
       }
     }
+
+    /* argument destructuring */
+    if (margs) {
+      node *n = margs;
+
+      pos = 1;
+      while (n) {
+        if (nint(n->car->car) == NODE_MASGN) {
+          gen_vmassignment(s, n->car->cdr->car, pos, NOVAL);
+        }
+        pos++;
+        n = n->cdr;
+      }
+    }
+    if (pargs) {
+      node *n = margs;
+
+      pos = ma+oa+ra+1;
+      while (n) {
+        if (nint(n->car->car) == NODE_MASGN) {
+          gen_vmassignment(s, n->car->cdr->car, pos, NOVAL);
+        }
+        pos++;
+        n = n->cdr;
+      }
+    }
   }
+
   codegen(s, tree->cdr->car, VAL);
   pop();
   if (s->pc > 0) {
@@ -1073,6 +1093,7 @@ gen_assignment(codegen_scope *s, node *tree, int sp, int val)
     idx = new_sym(s, nsym(tree));
     genop_2(s, OP_SETGV, sp, idx);
     break;
+  case NODE_ARG:
   case NODE_LVAR:
     idx = lv_idx(s, nsym(tree));
     if (idx > 0) {
@@ -1180,7 +1201,7 @@ gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val)
     pop_n(post+1);
     genop_3(s, OP_APOST, cursp(), n, post);
     n = 1;
-    if (t->car) {               /* rest */
+    if (t->car && t->car != (node*)-1) { /* rest */
       gen_assignment(s, t->car, cursp(), NOVAL);
     }
     if (t->cdr && t->cdr->car) {
@@ -1371,8 +1392,10 @@ codegen(codegen_scope *s, node *tree, int val)
     codegen_error(s, "too complex expression");
   }
   if (s->irep && s->filename_index != tree->filename_index) {
-    s->irep->filename = mrb_parser_get_filename(s->parser, s->filename_index);
-    mrb_debug_info_append_file(s->mrb, s->irep, s->debug_start_pos, s->pc);
+    const char *filename = mrb_parser_get_filename(s->parser, s->filename_index);
+
+    mrb_debug_info_append_file(s->mrb, s->irep->debug_info,
+                               filename, s->lines, s->debug_start_pos, s->pc);
     s->debug_start_pos = s->pc;
     s->filename_index = tree->filename_index;
     s->filename = mrb_parser_get_filename(s->parser, tree->filename_index);
@@ -2965,8 +2988,6 @@ scope_new(mrb_state *mrb, codegen_scope *prev, node *lv)
   p->debug_start_pos = 0;
   if (p->filename) {
     mrb_debug_info_alloc(mrb, p->irep);
-    p->irep->filename = p->filename;
-    p->irep->lines = p->lines;
   }
   else {
     p->irep->debug_info = NULL;
@@ -2984,34 +3005,22 @@ scope_finish(codegen_scope *s)
 {
   mrb_state *mrb = s->mrb;
   mrb_irep *irep = s->irep;
-  size_t fname_len;
-  char *fname;
 
   irep->flags = 0;
   if (s->iseq) {
     irep->iseq = (mrb_code *)codegen_realloc(s, s->iseq, sizeof(mrb_code)*s->pc);
     irep->ilen = s->pc;
-    if (s->lines) {
-      irep->lines = (uint16_t *)codegen_realloc(s, s->lines, sizeof(uint16_t)*s->pc);
-    }
-    else {
-      irep->lines = 0;
-    }
   }
   irep->pool = (mrb_value*)codegen_realloc(s, irep->pool, sizeof(mrb_value)*irep->plen);
   irep->syms = (mrb_sym*)codegen_realloc(s, irep->syms, sizeof(mrb_sym)*irep->slen);
   irep->reps = (mrb_irep**)codegen_realloc(s, irep->reps, sizeof(mrb_irep*)*irep->rlen);
   if (s->filename) {
-    irep->filename = mrb_parser_get_filename(s->parser, s->filename_index);
-    mrb_debug_info_append_file(mrb, irep, s->debug_start_pos, s->pc);
+    const char *filename = mrb_parser_get_filename(s->parser, s->filename_index);
 
-    fname_len = strlen(s->filename);
-    fname = (char*)codegen_malloc(s, fname_len + 1);
-    memcpy(fname, s->filename, fname_len);
-    fname[fname_len] = '\0';
-    irep->filename = fname;
-    irep->own_filename = TRUE;
+    mrb_debug_info_append_file(s->mrb, s->irep->debug_info,
+                               filename, s->lines, s->debug_start_pos, s->pc);
   }
+  mrb_free(s->mrb, s->lines);
 
   irep->nlocals = s->nlocals;
   irep->nregs = s->nregs;

--- a/mruby/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mruby/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -13,10 +13,9 @@ module Enumerable
   #    a.drop(3)             #=> [4, 5, 0]
 
   def drop(n)
-    raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
+    n = n.__to_int
     raise ArgumentError, "attempt to drop negative size" if n < 0
 
-    n = n.to_int
     ary = []
     self.each {|*val| n == 0 ? ary << val.__svalue : n -= 1 }
     ary
@@ -57,8 +56,8 @@ module Enumerable
   #    a.take(3)             #=> [1, 2, 3]
 
   def take(n)
-    raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
-    i = n.to_int
+    n = n.__to_int
+    i = n.to_i
     raise ArgumentError, "attempt to take negative size" if i < 0
     ary = []
     return ary if i == 0
@@ -113,12 +112,12 @@ module Enumerable
   #     [8, 9, 10]
 
   def each_cons(n, &block)
-    raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
+    n = n.__to_int
     raise ArgumentError, "invalid size" if n <= 0
 
     return to_enum(:each_cons,n) unless block
     ary = []
-    n = n.to_int
+    n = n.to_i
     self.each do |*val|
       ary.shift if ary.size == n
       ary << val.__svalue
@@ -141,12 +140,12 @@ module Enumerable
   #     [10]
 
   def each_slice(n, &block)
-    raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
+    n = n.__to_int
     raise ArgumentError, "invalid slice size" if n <= 0
 
     return to_enum(:each_slice,n) unless block
     ary = []
-    n = n.to_int
+    n = n.to_i
     self.each do |*val|
       ary << val.__svalue
       if ary.size == n
@@ -223,9 +222,7 @@ module Enumerable
       end
       return nil
     when 1
-      n = args[0]
-      raise TypeError, "no implicit conversion of #{n.class} into Integer" unless n.respond_to?(:to_int)
-      i = n.to_int
+      i = args[0].__to_int
       raise ArgumentError, "attempt to take negative size" if i < 0
       ary = []
       return ary if i == 0
@@ -673,13 +670,7 @@ module Enumerable
     if nv.nil?
       n = -1
     else
-      unless nv.respond_to?(:to_int)
-        raise TypeError, "no implicit conversion of #{nv.class} into Integer"
-      end
-      n = nv.to_int
-      unless n.kind_of?(Integer)
-        raise TypeError, "no implicit conversion of #{nv.class} into Integer"
-      end
+      n = nv.__to_int
       return nil if n <= 0
     end
 

--- a/mruby/mrbgems/mruby-enum-lazy/mrblib/lazy.rb
+++ b/mruby/mrbgems/mruby-enum-lazy/mrblib/lazy.rb
@@ -44,7 +44,7 @@ class Enumerator
 
     def to_enum(meth=:each, *args, &block)
       unless self.respond_to?(meth)
-        raise NoMethodError, "undefined method #{meth}"
+        raise ArgumentError, "undefined method #{meth}"
       end
       lz = Lazy.new(self, &block)
       lz.obj = self

--- a/mruby/mrbgems/mruby-enumerator/mrblib/enumerator.rb
+++ b/mruby/mrbgems/mruby-enumerator/mrblib/enumerator.rb
@@ -157,12 +157,10 @@ class Enumerator
   def with_index(offset=0, &block)
     return to_enum :with_index, offset unless block
 
-    offset = if offset.nil?
-      0
-    elsif offset.respond_to?(:to_int)
-      offset.to_int
+    if offset.nil?
+      offset = 0
     else
-      raise TypeError, "no implicit conversion of #{offset.class} into Integer"
+      offset = offset.__to_int
     end
 
     n = offset - 1
@@ -614,6 +612,9 @@ module Kernel
   #     enum.first(4) # => [1, 1, 1, 2]
   #
   def to_enum(meth=:each, *args)
+    unless self.respond_to?(meth)
+      raise ArgumentError, "undefined method #{meth}"
+    end
     Enumerator.new self, meth, *args
   end
   alias enum_for to_enum
@@ -623,9 +624,7 @@ module Enumerable
   # use Enumerator to use infinite sequence
   def zip(*args, &block)
     args = args.map do |a|
-      if a.respond_to?(:to_ary)
-        a.to_ary.to_enum(:each)
-      elsif a.respond_to?(:each)
+      if a.respond_to?(:each)
         a.to_enum(:each)
       else
         raise TypeError, "wrong argument type #{a.class} (must respond to :each)"

--- a/mruby/mrbgems/mruby-enumerator/test/enumerator.rb
+++ b/mruby/mrbgems/mruby-enumerator/test/enumerator.rb
@@ -22,8 +22,7 @@ assert 'Enumerator.new' do
   assert_equal [1,2,3], Enumerator.new(@obj, :foo, 1,2,3).to_a
   assert_equal [1,2,3], Enumerator.new { |y| i = 0; loop { y << (i += 1) } }.take(3)
   assert_raise(ArgumentError) { Enumerator.new }
-  enum = @obj.to_enum
-  assert_raise(NoMethodError) { enum.each {} }
+  assert_raise(ArgumentError) { @obj.to_enum }
 
   # examples
   fib = Enumerator.new do |y|
@@ -53,12 +52,6 @@ assert 'Enumerator#with_index' do
   a = []
   @obj.to_enum(:foo, 1, 2, 3).with_index(10).with_index(20) { |*i| a << i }
   assert_equal [[[1, 10], 20], [[2, 11], 21], [[3, 12], 22]], a
-end
-
-assert 'Enumerator#with_index nonnum offset' do
-  s = Object.new
-  def s.to_int; 1 end
-  assert_equal([[1,1],[2,2],[3,3]], @obj.to_enum(:foo, 1, 2, 3).with_index(s).to_a)
 end
 
 assert 'Enumerator#with_index string offset' do

--- a/mruby/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mruby/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -27,9 +27,9 @@ class Hash
     length = object.length
     if length == 1
       o = object[0]
-      if o.respond_to?(:to_hash)
+      if Hash === o
         h = self.new
-        object[0].to_hash.each { |k, v| h[k] = v }
+        o.each { |k, v| h[k] = v }
         return h
       elsif o.respond_to?(:to_a)
         h = self.new
@@ -62,25 +62,6 @@ class Hash
 
   ##
   # call-seq:
-  #     Hash.try_convert(obj) -> hash or nil
-  #
-  # Try to convert <i>obj</i> into a hash, using to_hash method.
-  # Returns converted hash or nil if <i>obj</i> cannot be converted
-  # for any reason.
-  #
-  #     Hash.try_convert({1=>2})   # => {1=>2}
-  #     Hash.try_convert("1=>2")   # => nil
-  #
-  def self.try_convert(obj)
-    if obj.respond_to?(:to_hash)
-      obj.to_hash
-    else
-      nil
-    end
-  end
-
-  ##
-  # call-seq:
   #     hsh.merge!(other_hash)                                 -> hsh
   #     hsh.merge!(other_hash){|key, oldval, newval| block}    -> hsh
   #
@@ -101,7 +82,7 @@ class Hash
   #
 
   def merge!(other, &block)
-    raise TypeError, "can't convert argument into Hash" unless other.respond_to?(:to_hash)
+    raise TypeError, "Hash required (#{other.class} given)" unless Hash === other
     if block
       other.each_key{|k|
         self[k] = (self.has_key?(k))? block.call(k, self[k], other[k]): other[k]
@@ -329,11 +310,7 @@ class Hash
   #     h1 < h1    #=> false
   #
   def <(hash)
-    begin
-      hash = hash.to_hash
-    rescue NoMethodError
-      raise TypeError, "can't convert #{hash.class} to Hash"
-    end
+    raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size < hash.size and all? {|key, val|
       hash.key?(key) and hash[key] == val
     }
@@ -353,11 +330,7 @@ class Hash
   #     h1 <= h1   #=> true
   #
   def <=(hash)
-    begin
-      hash = hash.to_hash
-    rescue NoMethodError
-      raise TypeError, "can't convert #{hash.class} to Hash"
-    end
+    raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size <= hash.size and all? {|key, val|
       hash.key?(key) and hash[key] == val
     }
@@ -377,11 +350,7 @@ class Hash
   #     h1 > h1    #=> false
   #
   def >(hash)
-    begin
-      hash = hash.to_hash
-    rescue NoMethodError
-      raise TypeError, "can't convert #{hash.class} to Hash"
-    end
+    raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size > hash.size and hash.all? {|key, val|
       key?(key) and self[key] == val
     }
@@ -401,11 +370,7 @@ class Hash
   #     h1 >= h1   #=> true
   #
   def >=(hash)
-    begin
-      hash = hash.to_hash
-    rescue NoMethodError
-      raise TypeError, "can't convert #{hash.class} to Hash"
-    end
+    raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size >= hash.size and hash.all? {|key, val|
       key?(key) and self[key] == val
     }

--- a/mruby/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mruby/mrbgems/mruby-hash-ext/test/hash.rb
@@ -45,12 +45,6 @@ assert('Hash.[] for sub class') do
   assert_equal(sub_hash_class, sub_hash.class)
 end
 
-assert('Hash.try_convert') do
-  assert_nil Hash.try_convert(nil)
-  assert_nil Hash.try_convert("{1=>2}")
-  assert_equal({1=>2}, Hash.try_convert({1=>2}))
-end
-
 assert('Hash#merge!') do
   a = { 'abc_key' => 'abc_value', 'cba_key' => 'cba_value' }
   b = { 'cba_key' => 'XXX',  'xyz_key' => 'xyz_value' }

--- a/mruby/mrbgems/mruby-io/src/file.c
+++ b/mruby/mrbgems/mruby-io/src/file.c
@@ -115,7 +115,7 @@ mrb_file_s_unlink(mrb_state *mrb, mrb_value obj)
   mrb_get_args(mrb, "*", &argv, &argc);
   for (i = 0; i < argc; i++) {
     const char *utf8_path;
-    pathv = mrb_convert_type(mrb, argv[i], MRB_TT_STRING, "String", "to_str");
+    pathv = mrb_ensure_string_type(mrb, argv[i]);
     utf8_path = mrb_string_value_cstr(mrb, &pathv);
     path = mrb_locale_from_utf8(utf8_path, -1);
     if (UNLINK(path) < 0) {

--- a/mruby/mrbgems/mruby-numeric-ext/src/numeric_ext.c
+++ b/mruby/mrbgems/mruby-numeric-ext/src/numeric_ext.c
@@ -2,13 +2,10 @@
 #include <mruby.h>
 
 static inline mrb_int
-to_int(mrb_value x)
+to_int(mrb_state *mrb, mrb_value x)
 {
-  double f;
-
-  if (mrb_fixnum_p(x)) return mrb_fixnum(x);
-  f = mrb_float(x);
-  return (mrb_int)f;
+  x = mrb_to_int(mrb, x);
+  return mrb_fixnum(x);
 }
 
 /*
@@ -28,7 +25,7 @@ mrb_int_chr(mrb_state *mrb, mrb_value x)
   mrb_int chr;
   char c;
 
-  chr = to_int(x);
+  chr = to_int(mrb, x);
   if (chr >= (1 << CHAR_BIT)) {
     mrb_raisef(mrb, E_RANGE_ERROR, "%S out of char range", x);
   }
@@ -48,8 +45,8 @@ mrb_int_allbits(mrb_state *mrb, mrb_value self)
 {
   mrb_int n, m;
 
-  n = to_int(self);
   mrb_get_args(mrb, "i", &m);
+  n = to_int(mrb, self);
   return mrb_bool_value((n & m) == m);
 }
 
@@ -64,8 +61,8 @@ mrb_int_anybits(mrb_state *mrb, mrb_value self)
 {
   mrb_int n, m;
 
-  n = to_int(self);
   mrb_get_args(mrb, "i", &m);
+  n = to_int(mrb, self);
   return mrb_bool_value((n & m) != 0);
 }
 
@@ -80,8 +77,8 @@ mrb_int_nobits(mrb_state *mrb, mrb_value self)
 {
   mrb_int n, m;
 
-  n = to_int(self);
   mrb_get_args(mrb, "i", &m);
+  n = to_int(mrb, self);
   return mrb_bool_value((n & m) == 0);
 }
 

--- a/mruby/mrbgems/mruby-pack/src/pack.c
+++ b/mruby/mrbgems/mruby-pack/src/pack.c
@@ -1124,14 +1124,16 @@ mrb_pack_pack(mrb_state *mrb, mrb_value ary)
       o = mrb_ary_ref(mrb, ary, aidx);
       if (type == PACK_TYPE_INTEGER) {
         o = mrb_to_int(mrb, o);
+      }
 #ifndef MRB_WITHOUT_FLOAT
-      } else if (type == PACK_TYPE_FLOAT) {
+      else if (type == PACK_TYPE_FLOAT) {
         if (!mrb_float_p(o)) {
           mrb_float f = mrb_to_flo(mrb, o);
           o = mrb_float_value(mrb, f);
         }
+      }
 #endif
-      } else if (type == PACK_TYPE_STRING) {
+      else if (type == PACK_TYPE_STRING) {
         if (!mrb_string_p(o)) {
           mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S into String", mrb_class_path(mrb, mrb_obj_class(mrb, o)));
         }

--- a/mruby/mrbgems/mruby-random/src/random.c
+++ b/mruby/mrbgems/mruby-random/src/random.c
@@ -79,12 +79,12 @@ get_opt(mrb_state* mrb)
   mrb_get_args(mrb, "|o", &arg);
 
   if (!mrb_nil_p(arg)) {
-    arg = mrb_check_convert_type(mrb, arg, MRB_TT_FIXNUM, "Fixnum", "to_int");
-    if (mrb_nil_p(arg)) {
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid argument type");
-    }
-    if (mrb_fixnum(arg) < 0) {
-      arg = mrb_fixnum_value(0 - mrb_fixnum(arg));
+    mrb_int i;
+
+    arg = mrb_to_int(mrb, arg);
+    i = mrb_fixnum(arg);
+    if (i < 0) {
+      arg = mrb_fixnum_value(0 - i);
     }
   }
   return arg;

--- a/mruby/mrbgems/mruby-random/test/random.rb
+++ b/mruby/mrbgems/mruby-random/test/random.rb
@@ -74,15 +74,3 @@ assert('Array#shuffle!(random)') do
 
   ary1 != [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] and 10.times { |x| ary1.include? x } and ary1 == ary2
 end
-
-assert('Array#sample checks input length after reading arguments') do
-  $ary = [1, 2, 3]
-  class ArrayChange
-    def to_i
-      $ary << 4
-      4
-    end
-  end
-
-  assert_equal [1, 2, 3, 4], $ary.sample(ArrayChange.new).sort
-end

--- a/mruby/mrbgems/mruby-range-ext/mrblib/range.rb
+++ b/mruby/mrbgems/mruby-range-ext/mrblib/range.rb
@@ -15,10 +15,7 @@ class Range
 
     raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1)" unless args.length == 1
     nv = args[0]
-    raise TypeError, "no implicit conversion from nil to integer" if nv.nil?
-    raise TypeError, "no implicit conversion of #{nv.class} into Integer" unless nv.respond_to?(:to_int)
-    n = nv.to_int
-    raise TypeError, "no implicit conversion of #{nv.class} into Integer" unless n.kind_of?(Integer)
+    n = nv.__to_int
     raise ArgumentError, "negative array size (or size too big)" unless 0 <= n
     ary = []
     each do |i|

--- a/mruby/mrbgems/mruby-socket/src/socket.c
+++ b/mruby/mrbgems/mruby-socket/src/socket.c
@@ -10,6 +10,7 @@
   #include <winsock2.h>
   #include <ws2tcpip.h>
   #include <windows.h>
+  #include <winerror.h>
 
   #define SHUT_RDWR SD_BOTH
   #ifndef _SSIZE_T_DEFINED

--- a/mruby/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/mruby/mrbgems/mruby-sprintf/src/sprintf.c
@@ -233,7 +233,7 @@ get_hash(mrb_state *mrb, mrb_value *hash, mrb_int argc, const mrb_value *argv)
   if (argc != 2) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "one hash required");
   }
-  tmp = mrb_check_convert_type(mrb, argv[1], MRB_TT_HASH, "Hash", "to_hash");
+  tmp = mrb_check_hash_type(mrb, argv[1]);
   if (mrb_nil_p(tmp)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "one hash required");
   }
@@ -552,7 +552,7 @@ mrb_str_format(mrb_state *mrb, mrb_int argc, const mrb_value *argv, mrb_value fm
 
   ++argc;
   --argv;
-  fmt = mrb_str_to_str(mrb, fmt);
+  mrb_to_str(mrb, fmt);
   p = RSTRING_PTR(fmt);
   end = p + RSTRING_LEN(fmt);
   blen = 0;

--- a/mruby/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/mruby/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -1,25 +1,6 @@
 class String
 
   ##
-  #  call-seq:
-  #     String.try_convert(obj) -> string or nil
-  #
-  # Try to convert <i>obj</i> into a String, using to_str method.
-  # Returns converted string or nil if <i>obj</i> cannot be converted
-  # for any reason.
-  #
-  #     String.try_convert("str")     #=> "str"
-  #     String.try_convert(/re/)      #=> nil
-  #
-  def self.try_convert(obj)
-    if obj.respond_to?(:to_str)
-      obj.to_str
-    else
-      nil
-    end
-  end
-
-  ##
   # call-seq:
   #    string.clear    ->  string
   #
@@ -142,7 +123,7 @@ class String
   #    "abcdef".casecmp("ABCDEF")    #=> 0
   #
   def casecmp(str)
-    self.downcase <=> str.to_str.downcase
+    self.downcase <=> str.__to_str.downcase
   rescue NoMethodError
     nil
   end

--- a/mruby/mrbgems/mruby-string-ext/test/string.rb
+++ b/mruby/mrbgems/mruby-string-ext/test/string.rb
@@ -4,13 +4,6 @@
 
 UTF8STRING = ("\343\201\202".size == 1)
 
-assert('String.try_convert') do
-  assert_nil String.try_convert(nil)
-  assert_nil String.try_convert(:foo)
-  assert_equal "", String.try_convert("")
-  assert_equal "1,2,3", String.try_convert("1,2,3")
-end
-
 assert('String#getbyte') do
   str1 = "hello"
   bytes1 = [104, 101, 108, 108, 111]
@@ -29,18 +22,6 @@ assert('String#setbyte') do
   str1.setbyte(0, h)
   assert_equal(h, str1.getbyte(0))
   assert_equal("Hello", str1)
-end
-
-assert("String#setbyte raises IndexError if arg conversion resizes String") do
-  $s = "01234\n"
-  class Tmp
-      def to_i
-          $s.chomp! ''
-          95
-      end
-  end
-  tmp = Tmp.new
-  assert_raise(IndexError) { $s.setbyte(5, tmp) }
 end
 
 assert('String#byteslice') do
@@ -126,12 +107,6 @@ assert('String#concat') do
   assert_equal "Hello World!", "Hello " << "World" << 33
   assert_equal "Hello World!", "Hello ".concat("World").concat(33)
 
-  o = Object.new
-  def o.to_str
-    "to_str"
-  end
-  assert_equal "hi to_str", "hi " << o
-
   assert_raise(TypeError) { "".concat(Object.new) }
 end
 
@@ -140,11 +115,6 @@ assert('String#casecmp') do
   assert_equal 0, "aBcDeF".casecmp("abcdef")
   assert_equal(-1, "abcdef".casecmp("abcdefg"))
   assert_equal 0, "abcdef".casecmp("ABCDEF")
-  o = Object.new
-  def o.to_str
-    "ABCDEF"
-  end
-  assert_equal 0, "abcdef".casecmp(o)
 end
 
 assert('String#count') do

--- a/mruby/mrbgems/mruby-struct/src/struct.c
+++ b/mruby/mrbgems/mruby-struct/src/struct.c
@@ -213,7 +213,7 @@ make_struct(mrb_state *mrb, mrb_value name, mrb_value members, struct RClass *kl
   }
   else {
     /* old style: should we warn? */
-    name = mrb_str_to_str(mrb, name);
+    mrb_to_str(mrb, name);
     id = mrb_obj_to_sym(mrb, name);
     if (!is_const_id(mrb, mrb_sym2name_len(mrb, id, NULL))) {
       mrb_name_error(mrb, id, "identifier %S needs to be constant", name);

--- a/mruby/mrblib/array.rb
+++ b/mruby/mrblib/array.rb
@@ -66,7 +66,7 @@ class Array
   #
   # ISO 15.2.12.5.15
   def initialize(size=0, obj=nil, &block)
-    raise TypeError, "expected Integer for 1st argument" unless size.kind_of? Integral
+    size = size.__to_int
     raise ArgumentError, "negative array size" if size < 0
 
     self.clear

--- a/mruby/mrblib/hash.rb
+++ b/mruby/mrblib/hash.rb
@@ -12,9 +12,7 @@ class Hash
   # ISO 15.2.13.4.1
   def ==(hash)
     return true if self.equal?(hash)
-    begin
-      hash = hash.to_hash
-    rescue NoMethodError
+    unless Hash === hash
       return false
     end
     return false if self.size != hash.size
@@ -32,9 +30,7 @@ class Hash
   # ISO 15.2.13.4.32 (x)
   def eql?(hash)
     return true if self.equal?(hash)
-    begin
-      hash = hash.to_hash
-    rescue NoMethodError
+    unless Hash === hash
       return false
     end
     return false if self.size != hash.size
@@ -153,9 +149,8 @@ class Hash
   #
   # ISO 15.2.13.4.23
   def replace(hash)
-    raise TypeError, "can't convert argument into Hash" unless hash.respond_to?(:to_hash)
+    raise TypeError, "Hash required (#{hash.class} given)" unless Hash === hash
     self.clear
-    hash = hash.to_hash
     hash.each_key{|k|
       self[k] = hash[k]
     }
@@ -178,8 +173,7 @@ class Hash
   #
   # ISO 15.2.13.4.22
   def merge(other, &block)
-    raise TypeError, "can't convert argument into Hash" unless other.respond_to?(:to_hash)
-    other = other.to_hash
+    raise TypeError, "Hash required (#{other.class} given)" unless Hash === other
     h = self.dup
     if block
       other.each_key{|k|

--- a/mruby/mrblib/string.rb
+++ b/mruby/mrblib/string.rb
@@ -12,7 +12,7 @@ class String
   def each_line(rs = "\n", &block)
     return to_enum(:each_line, rs, &block) unless block
     return block.call(self) if rs.nil?
-    rs = rs.to_str
+    rs.__to_str
     offset = 0
     rs_len = rs.length
     this = dup
@@ -67,7 +67,7 @@ class String
       block = nil
     end
     if !replace.nil? || !block
-      replace = replace.to_str
+      replace.__to_str
     end
     offset = 0
     result = []
@@ -129,12 +129,12 @@ class String
     end
 
     pattern, replace = *args
-    pattern = pattern.to_str
+    pattern.__to_str
     if args.length == 2 && block
       block = nil
     end
     unless block
-      replace = replace.to_str
+      replace.__to_str
     end
     result = []
     this = dup
@@ -245,14 +245,13 @@ class String
   ##
   # ISO 15.2.10.5.3
   def =~(re)
-    raise TypeError, "type mismatch: String given" if re.respond_to? :to_str
     re =~ self
   end
 
   ##
   # ISO 15.2.10.5.27
   def match(re, &block)
-    if re.respond_to? :to_str
+    if String === re
       if Object.const_defined?(:Regexp)
         r = Regexp.new(re)
         r.match(self, &block)

--- a/mruby/src/array.c
+++ b/mruby/src/array.c
@@ -1058,7 +1058,7 @@ mrb_ary_rindex_m(mrb_state *mrb, mrb_value self)
 MRB_API mrb_value
 mrb_ary_splat(mrb_state *mrb, mrb_value v)
 {
-  mrb_value a, recv_class;
+  mrb_value a;
 
   if (mrb_array_p(v)) {
     return v;
@@ -1069,22 +1069,11 @@ mrb_ary_splat(mrb_state *mrb, mrb_value v)
   }
 
   a = mrb_funcall(mrb, v, "to_a", 0);
-  if (mrb_array_p(a)) {
-    return a;
-  }
-  else if (mrb_nil_p(a)) {
+  if (mrb_nil_p(a)) {
     return mrb_ary_new_from_values(mrb, 1, &v);
   }
-  else {
-    recv_class = mrb_obj_value(mrb_obj_class(mrb, v));
-    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S to Array (%S#to_a gives %S)",
-      recv_class,
-      recv_class,
-      mrb_obj_value(mrb_obj_class(mrb, a))
-    );
-    /* not reached */
-    return mrb_undef_value();
-  }
+  mrb_ensure_array_type(mrb, a);
+  return a;
 }
 
 static mrb_value
@@ -1120,12 +1109,6 @@ mrb_ary_empty_p(mrb_state *mrb, mrb_value self)
   struct RArray *a = mrb_ary_ptr(self);
 
   return mrb_bool_value(ARY_LEN(a) == 0);
-}
-
-MRB_API mrb_value
-mrb_check_array_type(mrb_state *mrb, mrb_value ary)
-{
-  return mrb_check_convert_type(mrb, ary, MRB_TT_ARRAY, "Array", "to_ary");
 }
 
 MRB_API mrb_value
@@ -1181,7 +1164,7 @@ join_ary(mrb_state *mrb, mrb_value ary, mrb_value sep, mrb_value list)
           val = tmp;
           goto str_join;
         }
-        tmp = mrb_check_convert_type(mrb, val, MRB_TT_ARRAY, "Array", "to_ary");
+        tmp = mrb_check_array_type(mrb, val);
         if (!mrb_nil_p(tmp)) {
           val = tmp;
           goto ary_join;

--- a/mruby/src/class.c
+++ b/mruby/src/class.c
@@ -492,34 +492,31 @@ mrb_notimplement_m(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
-static mrb_value
-check_type(mrb_state *mrb, mrb_value val, enum mrb_vtype t, const char *c, const char *m)
-{
-  mrb_value tmp;
-
-  tmp = mrb_check_convert_type(mrb, val, t, c, m);
-  if (mrb_nil_p(tmp)) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "expected %S", mrb_str_new_cstr(mrb, c));
-  }
-  return tmp;
-}
+#define CHECK_TYPE(mrb, val, t, c) do { \
+  if (mrb_type(val) != (t)) {\
+    mrb_raisef(mrb, E_TYPE_ERROR, "expected %S", mrb_str_new_lit(mrb, c));\
+  }\
+} while (0)
 
 static mrb_value
 to_str(mrb_state *mrb, mrb_value val)
 {
-  return check_type(mrb, val, MRB_TT_STRING, "String", "to_str");
+  CHECK_TYPE(mrb, val, MRB_TT_STRING, "String");
+  return val;
 }
 
 static mrb_value
 to_ary(mrb_state *mrb, mrb_value val)
 {
-  return check_type(mrb, val, MRB_TT_ARRAY, "Array", "to_ary");
+  CHECK_TYPE(mrb, val, MRB_TT_ARRAY, "Array");
+  return val;
 }
 
 static mrb_value
 to_hash(mrb_state *mrb, mrb_value val)
 {
-  return check_type(mrb, val, MRB_TT_HASH, "Hash", "to_hash");
+  CHECK_TYPE(mrb, val, MRB_TT_HASH, "Hash");
+  return val;
 }
 
 #define to_sym(mrb, ss) mrb_obj_to_sym(mrb, ss)
@@ -1972,7 +1969,7 @@ mrb_mod_const_get(mrb_state *mrb, mrb_value mod)
   }
 
   /* const get with class path string */
-  path = mrb_string_type(mrb, path);
+  path = mrb_ensure_string_type(mrb, path);
   ptr = RSTRING_PTR(path);
   len = RSTRING_LEN(path);
   off = 0;

--- a/mruby/src/codedump.c
+++ b/mruby/src/codedump.c
@@ -17,6 +17,7 @@ print_r(mrb_state *mrb, mrb_irep *irep, size_t n)
     if (irep->lv[i].r == n) {
       mrb_sym sym = irep->lv[i].name;
       printf(" R%d:%s", (int)n, mrb_sym2name(mrb, sym));
+      break;
     }
   }
 }
@@ -81,8 +82,9 @@ codedump(mrb_state *mrb, mrb_irep *irep)
 
     printf("local variable names:\n");
     for (i = 1; i < irep->nlocals; ++i) {
-      char const *n = mrb_sym2name(mrb, irep->lv[i - 1].name);
-      printf("  R%d:%s\n", irep->lv[i - 1].r, n? n : "");
+      char const *s = mrb_sym2name(mrb, irep->lv[i - 1].name);
+      int n = irep->lv[i - 1].r ? irep->lv[i - 1].r : i;
+      printf("  R%d:%s\n", n, s ? s : "");
     }
   }
 

--- a/mruby/src/debug.c
+++ b/mruby/src/debug.c
@@ -55,7 +55,7 @@ mrb_debug_get_filename(mrb_irep *irep, ptrdiff_t pc)
 {
   if (irep && pc >= 0 && pc < irep->ilen) {
     mrb_irep_debug_info_file* f = NULL;
-    if (!irep->debug_info) { return irep->filename; }
+    if (!irep->debug_info) return NULL;
     else if ((f = get_file(irep->debug_info, (uint32_t)pc))) {
       return f->filename;
     }
@@ -69,7 +69,7 @@ mrb_debug_get_line(mrb_irep *irep, ptrdiff_t pc)
   if (irep && pc >= 0 && pc < irep->ilen) {
     mrb_irep_debug_info_file* f = NULL;
     if (!irep->debug_info) {
-      return irep->lines? irep->lines[pc] : -1;
+      return -1;
     }
     else if ((f = get_file(irep->debug_info, (uint32_t)pc))) {
       switch (f->line_type) {
@@ -122,82 +122,80 @@ mrb_debug_info_alloc(mrb_state *mrb, mrb_irep *irep)
 }
 
 MRB_API mrb_irep_debug_info_file*
-mrb_debug_info_append_file(mrb_state *mrb, mrb_irep *irep,
+mrb_debug_info_append_file(mrb_state *mrb, mrb_irep_debug_info *d,
+                           const char *filename, uint16_t *lines,
                            uint32_t start_pos, uint32_t end_pos)
 {
-  mrb_irep_debug_info *info;
-  mrb_irep_debug_info_file *ret;
+  mrb_irep_debug_info_file *f;
   uint32_t file_pc_count;
   size_t fn_len;
   mrb_int len;
   uint32_t i;
 
-  if (!irep->debug_info) { return NULL; }
+  if (!d) return NULL;
+  if (start_pos == end_pos) return NULL;
 
-  mrb_assert(irep->filename);
-  mrb_assert(irep->lines);
+  mrb_assert(filename);
+  mrb_assert(lines);
 
-  info = irep->debug_info;
-
-  if (info->flen > 0 && strcmp(irep->filename, info->files[info->flen - 1]->filename) == 0) {
+  if (d->flen > 0 && strcmp(filename, d->files[d->flen - 1]->filename) == 0) {
     return NULL;
   }
 
-  ret = (mrb_irep_debug_info_file *)mrb_malloc(mrb, sizeof(*ret));
-  info->files =
-      (mrb_irep_debug_info_file**)(
-          info->files
-          ? mrb_realloc(mrb, info->files, sizeof(mrb_irep_debug_info_file*) * (info->flen + 1))
+  f = (mrb_irep_debug_info_file*)mrb_malloc(mrb, sizeof(*f));
+  d->files = (mrb_irep_debug_info_file**)(
+          d->files
+          ? mrb_realloc(mrb, d->files, sizeof(mrb_irep_debug_info_file*) * (d->flen + 1))
           : mrb_malloc(mrb, sizeof(mrb_irep_debug_info_file*)));
-  info->files[info->flen++] = ret;
+  d->files[d->flen++] = f;
 
   file_pc_count = end_pos - start_pos;
 
-  ret->start_pos = start_pos;
-  info->pc_count = end_pos;
+  f->start_pos = start_pos;
+  d->pc_count = end_pos;
 
-  fn_len = strlen(irep->filename);
-  ret->filename_sym = mrb_intern(mrb, irep->filename, fn_len);
+  fn_len = strlen(filename);
+  f->filename_sym = mrb_intern(mrb, filename, fn_len);
   len = 0;
-  ret->filename = mrb_sym2name_len(mrb, ret->filename_sym, &len);
+  f->filename = mrb_sym2name_len(mrb, f->filename_sym, &len);
 
-  ret->line_type = select_line_type(irep->lines + start_pos, end_pos - start_pos);
-  ret->lines.ptr = NULL;
+  f->line_type = select_line_type(lines + start_pos, end_pos - start_pos);
+  f->lines.ptr = NULL;
 
-  switch (ret->line_type) {
+  switch (f->line_type) {
     case mrb_debug_line_ary:
-      ret->line_entry_count = file_pc_count;
-      ret->lines.ary = (uint16_t*)mrb_malloc(mrb, sizeof(uint16_t) * file_pc_count);
+      f->line_entry_count = file_pc_count;
+      f->lines.ary = (uint16_t*)mrb_malloc(mrb, sizeof(uint16_t) * file_pc_count);
       for (i = 0; i < file_pc_count; ++i) {
-        ret->lines.ary[i] = irep->lines[start_pos + i];
+        f->lines.ary[i] = lines[start_pos + i];
       }
       break;
 
     case mrb_debug_line_flat_map: {
       uint16_t prev_line = 0;
       mrb_irep_debug_info_line m;
-      ret->lines.flat_map = (mrb_irep_debug_info_line*)mrb_malloc(mrb, sizeof(mrb_irep_debug_info_line) * 1);
-      ret->line_entry_count = 0;
+      f->lines.flat_map = (mrb_irep_debug_info_line*)mrb_malloc(mrb, sizeof(mrb_irep_debug_info_line) * 1);
+      f->line_entry_count = 0;
       for (i = 0; i < file_pc_count; ++i) {
-        if (irep->lines[start_pos + i] == prev_line) { continue; }
+        if (lines[start_pos + i] == prev_line) { continue; }
 
-        ret->lines.flat_map = (mrb_irep_debug_info_line*)mrb_realloc(
-            mrb, ret->lines.flat_map,
-            sizeof(mrb_irep_debug_info_line) * (ret->line_entry_count + 1));
+        f->lines.flat_map = (mrb_irep_debug_info_line*)mrb_realloc(
+            mrb, f->lines.flat_map,
+            sizeof(mrb_irep_debug_info_line) * (f->line_entry_count + 1));
         m.start_pos = start_pos + i;
-        m.line = irep->lines[start_pos + i];
-        ret->lines.flat_map[ret->line_entry_count] = m;
+        m.line = lines[start_pos + i];
+        f->lines.flat_map[f->line_entry_count] = m;
 
         /* update */
-        ++ret->line_entry_count;
-        prev_line = irep->lines[start_pos + i];
+        ++f->line_entry_count;
+        prev_line = lines[start_pos + i];
       }
     } break;
 
     default: mrb_assert(0); break;
   }
 
-  return ret;
+  return f;
 }
 
 MRB_API void

--- a/mruby/src/dump.c
+++ b/mruby/src/dump.c
@@ -353,118 +353,6 @@ write_section_irep(mrb_state *mrb, mrb_irep *irep, uint8_t *bin, size_t *len_p, 
   return MRB_DUMP_OK;
 }
 
-static int
-write_section_lineno_header(mrb_state *mrb, size_t section_size, uint8_t *bin)
-{
-  struct rite_section_lineno_header *header = (struct rite_section_lineno_header*)bin;
-
-  memcpy(header->section_ident, RITE_SECTION_LINENO_IDENT, sizeof(header->section_ident));
-  uint32_to_bin((uint32_t)section_size, header->section_size);
-
-  return MRB_DUMP_OK;
-}
-
-static size_t
-get_lineno_record_size(mrb_state *mrb, mrb_irep *irep)
-{
-  size_t size = 0;
-
-  size += sizeof(uint32_t); /* record size */
-  size += sizeof(uint16_t); /* filename size */
-  if (irep->filename) {
-    size += strlen(irep->filename); /* filename */
-  }
-  size += sizeof(uint32_t); /* niseq */
-  if (irep->lines) {
-    size += sizeof(uint16_t) * irep->ilen; /* lineno */
-  }
-
-  return size;
-}
-
-static size_t
-write_lineno_record_1(mrb_state *mrb, mrb_irep *irep, uint8_t* bin)
-{
-  uint8_t *cur = bin;
-  int iseq_no;
-  size_t filename_len;
-  ptrdiff_t diff;
-
-  cur += sizeof(uint32_t); /* record size */
-
-  if (irep->filename) {
-    filename_len = strlen(irep->filename);
-  }
-  else {
-    filename_len = 0;
-  }
-  mrb_assert_int_fit(size_t, filename_len, uint16_t, UINT16_MAX);
-  cur += uint16_to_bin((uint16_t)filename_len, cur); /* filename size */
-
-  if (filename_len) {
-    memcpy(cur, irep->filename, filename_len);
-    cur += filename_len; /* filename */
-  }
-
-  if (irep->lines) {
-    mrb_assert_int_fit(size_t, irep->ilen, uint32_t, UINT32_MAX);
-    cur += uint32_to_bin((uint32_t)(irep->ilen), cur); /* niseq */
-    for (iseq_no = 0; iseq_no < irep->ilen; iseq_no++) {
-      cur += uint16_to_bin(irep->lines[iseq_no], cur); /* opcode */
-    }
-  }
-  else {
-    cur += uint32_to_bin(0, cur); /* niseq */
-  }
-
-  diff = cur - bin;
-  mrb_assert_int_fit(ptrdiff_t, diff, uint32_t, UINT32_MAX);
-
-  uint32_to_bin((uint32_t)diff, bin); /* record size */
-
-  mrb_assert_int_fit(ptrdiff_t, diff, size_t, SIZE_MAX);
-  return (size_t)diff;
-}
-
-static size_t
-write_lineno_record(mrb_state *mrb, mrb_irep *irep, uint8_t* bin)
-{
-  size_t rlen, size = 0;
-  int i;
-
-  rlen = write_lineno_record_1(mrb, irep, bin);
-  bin += rlen;
-  size += rlen;
-  for (i=0; i<irep->rlen; i++) {
-    rlen = write_lineno_record(mrb, irep, bin);
-    bin += rlen;
-    size += rlen;
-  }
-  return size;
-}
-
-static int
-write_section_lineno(mrb_state *mrb, mrb_irep *irep, uint8_t *bin)
-{
-  size_t section_size = 0;
-  size_t rlen = 0; /* size of irep record */
-  uint8_t *cur = bin;
-
-  if (mrb == NULL || bin == NULL) {
-    return MRB_DUMP_INVALID_ARGUMENT;
-  }
-
-  cur += sizeof(struct rite_section_lineno_header);
-  section_size += sizeof(struct rite_section_lineno_header);
-
-  rlen = write_lineno_record(mrb, irep, cur);
-  section_size += rlen;
-
-  write_section_lineno_header(mrb, section_size, bin);
-
-  return MRB_DUMP_OK;
-}
-
 static size_t
 get_debug_record_size(mrb_state *mrb, mrb_irep *irep)
 {
@@ -838,26 +726,26 @@ write_rite_binary_header(mrb_state *mrb, size_t binary_size, uint8_t *bin, uint8
 }
 
 static mrb_bool
-is_debug_info_defined(mrb_irep *irep)
+debug_info_defined_p(mrb_irep *irep)
 {
   int i;
 
   if (!irep->debug_info) return FALSE;
   for (i=0; i<irep->rlen; i++) {
-    if (!is_debug_info_defined(irep->reps[i])) return FALSE;
+    if (!debug_info_defined_p(irep->reps[i])) return FALSE;
   }
   return TRUE;
 }
 
 static mrb_bool
-is_lv_defined(mrb_irep *irep)
+lv_defined_p(mrb_irep *irep)
 {
   int i;
 
   if (irep->lv) { return TRUE; }
 
   for (i = 0; i < irep->rlen; ++i) {
-    if (is_lv_defined(irep->reps[i])) { return TRUE; }
+    if (lv_defined_p(irep->reps[i])) { return TRUE; }
   }
 
   return FALSE;
@@ -886,7 +774,7 @@ dump_irep(mrb_state *mrb, mrb_irep *irep, uint8_t flags, uint8_t **bin, size_t *
   size_t section_irep_size;
   size_t section_lineno_size = 0, section_lv_size = 0;
   uint8_t *cur = NULL;
-  mrb_bool const debug_info_defined = is_debug_info_defined(irep), lv_defined = is_lv_defined(irep);
+  mrb_bool const debug_info_defined = debug_info_defined_p(irep), lv_defined = lv_defined_p(irep);
   mrb_sym *lv_syms = NULL; uint32_t lv_syms_len = 0;
   mrb_sym *filenames = NULL; uint16_t filenames_len = 0;
 
@@ -910,10 +798,6 @@ dump_irep(mrb_state *mrb, mrb_irep *irep, uint8_t flags, uint8_t **bin, size_t *
       section_lineno_size += get_filename_table_size(mrb, irep, &filenames, &filenames_len);
 
       section_lineno_size += get_debug_record_size(mrb, irep);
-    }
-    else {
-      section_lineno_size += sizeof(struct rite_section_lineno_header);
-      section_lineno_size += get_lineno_record_size(mrb, irep);
     }
   }
 
@@ -942,12 +826,9 @@ dump_irep(mrb_state *mrb, mrb_irep *irep, uint8_t flags, uint8_t **bin, size_t *
   if (flags & DUMP_DEBUG_INFO) {
     if (debug_info_defined) {
       result = write_section_debug(mrb, irep, cur, filenames, filenames_len);
-    }
-    else {
-      result = write_section_lineno(mrb, irep, cur);
-    }
-    if (result != MRB_DUMP_OK) {
-      goto error_exit;
+      if (result != MRB_DUMP_OK) {
+        goto error_exit;
+      }
     }
     cur += section_lineno_size;
   }

--- a/mruby/src/enum.c
+++ b/mruby/src/enum.c
@@ -14,23 +14,9 @@ enum_update_hash(mrb_state *mrb, mrb_value self)
   mrb_int hash;
   mrb_int index;
   mrb_int hv;
-  mrb_value item_hash;
 
-  mrb_get_args(mrb, "iio", &hash, &index, &item_hash);
-  if (mrb_fixnum_p(item_hash)) {
-    hv = mrb_fixnum(item_hash);
-  }
-#ifndef MRB_WITHOUT_FLOAT
-  else if (mrb_float_p(item_hash)) {
-    hv = (mrb_int)mrb_float(item_hash);
-  }
-#endif
-  else {
-    mrb_raise(mrb, E_TYPE_ERROR, "can't calculate hash");
-    /* not reached */
-    hv = 0;
-  }
-  hash ^= (hv << (index % 16));
+  mrb_get_args(mrb, "iii", &hash, &index, &hv);
+  hash ^= ((uint32_t)hv << (index % 16));
 
   return mrb_fixnum_value(hash);
 }

--- a/mruby/src/error.c
+++ b/mruby/src/error.c
@@ -28,7 +28,7 @@ mrb_exc_new(mrb_state *mrb, struct RClass *c, const char *ptr, size_t len)
 MRB_API mrb_value
 mrb_exc_new_str(mrb_state *mrb, struct RClass* c, mrb_value str)
 {
-  str = mrb_str_to_str(mrb, str);
+  mrb_to_str(mrb, str);
   return mrb_obj_new(mrb, c, 1, &str);
 }
 

--- a/mruby/src/fmt_fp.c
+++ b/mruby/src/fmt_fp.c
@@ -379,7 +379,7 @@ mrb_float_to_str(mrb_state *mrb, mrb_value flo, const char *fmt)
 mrb_value
 mrb_float_to_str(mrb_state *mrb, mrb_value flo, const char *fmt)
 {
-  char buf[24];
+  char buf[25];
 
   snprintf(buf, sizeof(buf), fmt, mrb_float(flo));
   return mrb_str_new_cstr(mrb, buf);

--- a/mruby/src/hash.c
+++ b/mruby/src/hash.c
@@ -17,11 +17,12 @@ mrb_int mrb_float_id(mrb_float f);
 #endif
 
 /* return non zero to break the loop */
-typedef int (sg_foreach_func)(mrb_state *mrb,mrb_value key, mrb_value val, void *data);
+typedef int (ht_foreach_func)(mrb_state *mrb,mrb_value key, mrb_value val, void *data);
 
-#ifndef MRB_SG_SEGMENT_SIZE
-#define MRB_SG_SEGMENT_SIZE 5
+#ifndef MRB_HT_INIT_SIZE
+#define MRB_HT_INIT_SIZE 4
 #endif
+#define HT_SEG_INCREASE_RATIO 1.2
 
 struct segkv {
   mrb_value key;
@@ -29,8 +30,9 @@ struct segkv {
 };
 
 typedef struct segment {
+  uint16_t size;
   struct segment *next;
-  struct segkv e[MRB_SG_SEGMENT_SIZE];
+  struct segkv e[];
 } segment;
 
 typedef struct segindex {
@@ -40,16 +42,16 @@ typedef struct segindex {
 } segindex;
 
 /* Instance variable table structure */
-typedef struct seglist {
+typedef struct htable {
   segment *rootseg;
   segment *lastseg;
   mrb_int size;
-  mrb_int last_len;
+  uint16_t last_len;
   segindex *index;
-} seglist;
+} htable;
 
 static /* inline */ size_t
-sg_hash_func(mrb_state *mrb, seglist *t, mrb_value key)
+ht_hash_func(mrb_state *mrb, htable *t, mrb_value key)
 {
   enum mrb_vtype tt = mrb_type(key);
   mrb_value hv;
@@ -84,7 +86,7 @@ sg_hash_func(mrb_state *mrb, seglist *t, mrb_value key)
 }
 
 static inline mrb_bool
-sg_hash_equal(mrb_state *mrb, seglist *t, mrb_value a, mrb_value b)
+ht_hash_equal(mrb_state *mrb, htable *t, mrb_value a, mrb_value b)
 {
   enum mrb_vtype tt = mrb_type(a);
 
@@ -134,12 +136,12 @@ sg_hash_equal(mrb_state *mrb, seglist *t, mrb_value a, mrb_value b)
 }
 
 /* Creates the instance variable table. */
-static seglist*
-sg_new(mrb_state *mrb)
+static htable*
+ht_new(mrb_state *mrb)
 {
-  seglist *t;
+  htable *t;
 
-  t = (seglist*)mrb_malloc(mrb, sizeof(seglist));
+  t = (htable*)mrb_malloc(mrb, sizeof(htable));
   t->size = 0;
   t->rootseg =  NULL;
   t->lastseg =  NULL;
@@ -163,11 +165,11 @@ sg_new(mrb_state *mrb)
 #define UPPER_BOUND(x) ((x)>>2|(x)>>1)
 #endif
 
-#define SG_MASK(index) ((index->capa)-1)
+#define HT_MASK(index) ((index->capa)-1)
 
-/* Build index for the segment list */
+/* Build index for the hash table */
 static void
-sg_index(mrb_state *mrb, seglist *t)
+ht_index(mrb_state *mrb, htable *t)
 {
   size_t size = (size_t)t->size;
   size_t mask;
@@ -175,14 +177,6 @@ sg_index(mrb_state *mrb, seglist *t)
   segment *seg;
   size_t i;
 
-  if (size < MRB_SG_SEGMENT_SIZE) {
-    if (index) {
-    failed:
-      mrb_free(mrb, index);
-      t->index = NULL;
-    }
-    return;
-  }
   /* allocate index table */
   if (index && index->size >= UPPER_BOUND(index->capa)) {
     size = index->capa+1;
@@ -190,7 +184,11 @@ sg_index(mrb_state *mrb, seglist *t)
   power2(size);
   if (!index || index->capa < size) {
     index = (segindex*)mrb_realloc_simple(mrb, index, sizeof(segindex)+sizeof(struct segkv*)*size);
-    if (index == NULL) goto failed;
+    if (index == NULL) {
+      mrb_free(mrb, index);
+      t->index = NULL;
+      return;
+    }
     t->index = index;
   }
   index->size = t->size;
@@ -200,10 +198,10 @@ sg_index(mrb_state *mrb, seglist *t)
   }
 
   /* rebuld index */
-  mask = SG_MASK(index);
+  mask = HT_MASK(index);
   seg = t->rootseg;
   while (seg) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+    for (i=0; i<seg->size; i++) {
       mrb_value key;
       size_t k, step = 0;
 
@@ -212,7 +210,7 @@ sg_index(mrb_state *mrb, seglist *t)
       }
       key = seg->e[i].key;
       if (mrb_undef_p(key)) continue;
-      k = sg_hash_func(mrb, t, key) & mask;
+      k = ht_hash_func(mrb, t, key) & mask;
       while (index->table[k]) {
         k = (k+(++step)) & mask;
       }
@@ -222,9 +220,9 @@ sg_index(mrb_state *mrb, seglist *t)
   }
 }
 
-/* Compacts the segment list removing deleted entries. */
+/* Compacts the hash table removing deleted entries. */
 static void
-sg_compact(mrb_state *mrb, seglist *t)
+ht_compact(mrb_state *mrb, htable *t)
 {
   segment *seg;
   mrb_int i;
@@ -235,11 +233,11 @@ sg_compact(mrb_state *mrb, seglist *t)
   if (t == NULL) return;
   seg = t->rootseg;
   if (t->index && (size_t)t->size == t->index->size) {
-    sg_index(mrb, t);
+    ht_index(mrb, t);
     return;
   }
   while (seg) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+    for (i=0; i<seg->size; i++) {
       mrb_value k = seg->e[i].key;
 
       if (!seg->next && i >= t->last_len) {
@@ -255,7 +253,7 @@ sg_compact(mrb_state *mrb, seglist *t)
         size++;
         if (seg2 != NULL) {
           seg2->e[i2++] = seg->e[i];
-          if (i2 >= MRB_SG_SEGMENT_SIZE) {
+          if (i2 >= seg2->size) {
             seg2 = seg2->next;
             i2 = 0;
           }
@@ -279,13 +277,31 @@ sg_compact(mrb_state *mrb, seglist *t)
     }
   }
   if (t->index) {
-    sg_index(mrb, t);
+    ht_index(mrb, t);
   }
 }
 
-/* Set the value for the key in the indexed segment list. */
+static segment*
+segment_alloc(mrb_state *mrb, segment *seg)
+{
+  uint32_t size;
+
+  if (!seg) size = MRB_HT_INIT_SIZE;
+  else {
+    size = seg->size*HT_SEG_INCREASE_RATIO + 1;
+    if (size > UINT16_MAX) size = UINT16_MAX;
+  }
+
+  seg = (segment*)mrb_malloc(mrb, sizeof(segment)+sizeof(struct segkv)*size);
+  seg->size = size;
+  seg->next = NULL;
+
+  return seg;
+}
+
+/* Set the value for the key in the indexed table. */
 static void
-sg_index_put(mrb_state *mrb, seglist *t, mrb_value key, mrb_value val)
+ht_index_put(mrb_state *mrb, htable *t, mrb_value key, mrb_value val)
 {
   segindex *index = t->index;
   size_t k, sp, step = 0, mask;
@@ -293,18 +309,18 @@ sg_index_put(mrb_state *mrb, seglist *t, mrb_value key, mrb_value val)
 
   if (index->size >= UPPER_BOUND(index->capa)) {
     /* need to expand table */
-    sg_compact(mrb, t);
+    ht_compact(mrb, t);
     index = t->index;
   }
-  mask = SG_MASK(index);
+  mask = HT_MASK(index);
   sp = index->capa;
-  k = sg_hash_func(mrb, t, key) & mask;
+  k = ht_hash_func(mrb, t, key) & mask;
   while (index->table[k]) {
     mrb_value key2 = index->table[k]->key;
     if (mrb_undef_p(key2)) {
       if (sp == index->capa) sp = k;
     }
-    else if (sg_hash_equal(mrb, t, key, key2)) {
+    else if (ht_hash_equal(mrb, t, key, key2)) {
       index->table[k]->val = val;
       return;
     }
@@ -316,11 +332,11 @@ sg_index_put(mrb_state *mrb, seglist *t, mrb_value key, mrb_value val)
 
   /* put the value at the last */
   seg = t->lastseg;
-  if (t->last_len < MRB_SG_SEGMENT_SIZE) {
+  if (t->last_len < seg->size) {
     index->table[k] = &seg->e[t->last_len++];
   }
   else {                        /* append a new segment */
-    seg->next = (segment*)mrb_malloc(mrb, sizeof(segment));
+    seg->next = segment_alloc(mrb, seg);
     seg = seg->next;
     seg->next = NULL;
     t->lastseg = seg;
@@ -333,21 +349,21 @@ sg_index_put(mrb_state *mrb, seglist *t, mrb_value key, mrb_value val)
   t->size++;
 }
 
-/* Set the value for the key in the segment list. */
+/* Set the value for the key in the table. */
 static void
-sg_put(mrb_state *mrb, seglist *t, mrb_value key, mrb_value val)
+ht_put(mrb_state *mrb, htable *t, mrb_value key, mrb_value val)
 {
   segment *seg;
   mrb_int i, deleted = 0;
 
   if (t == NULL) return;
   if (t->index) {
-    sg_index_put(mrb, t, key, val);
+    ht_index_put(mrb, t, key, val);
     return;
   }
   seg = t->rootseg;
   while (seg) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+    for (i=0; i<seg->size; i++) {
       mrb_value k = seg->e[i].key;
       /* Found room in last segment after last_len */
       if (!seg->next && i >= t->last_len) {
@@ -361,49 +377,58 @@ sg_put(mrb_state *mrb, seglist *t, mrb_value key, mrb_value val)
         deleted++;
         continue;
       }
-      if (sg_hash_equal(mrb, t, k, key)) {
+      if (ht_hash_equal(mrb, t, k, key)) {
         seg->e[i].val = val;
         return;
       }
     }
     seg = seg->next;
   }
-
   /* Not found */
-  if (deleted > MRB_SG_SEGMENT_SIZE) {
-    sg_compact(mrb, t);
+
+  /* Compact if last segment has room */
+  if (deleted > 0 && deleted > MRB_HT_INIT_SIZE) {
+    ht_compact(mrb, t);
   }
   t->size++;
 
-  seg = (segment*)mrb_malloc(mrb, sizeof(segment));
-  seg->next = NULL;
-  seg->e[0].key = key;
-  seg->e[0].val = val;
-  t->last_len = 1;
-  if (t->rootseg == NULL) {
-    t->rootseg = seg;
+  /* check if thre's room after compaction */
+  if (t->lastseg && t->last_len < t->lastseg->size) {
+    seg = t->lastseg;
+    i = t->last_len;
   }
   else {
-    t->lastseg->next = seg;
+    /* append new segment */
+    seg = segment_alloc(mrb, t->lastseg);
+    i = 0;
+    if (t->rootseg == NULL) {
+      t->rootseg = seg;
+    }
+    else {
+      t->lastseg->next = seg;
+    }
+    t->lastseg = seg;
   }
-  t->lastseg = seg;
-  if (t->index == NULL && t->size > MRB_SG_SEGMENT_SIZE*4) {
-    sg_index(mrb, t);
+  seg->e[i].key = key;
+  seg->e[i].val = val;
+  t->last_len = i+1;
+  if (t->index == NULL && t->size > MRB_HT_INIT_SIZE*4) {
+    ht_index(mrb, t);
   }
 }
 
-/* Get a value for a key from the indexed segment list. */
+/* Get a value for a key from the indexed table. */
 static mrb_bool
-sg_index_get(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
+ht_index_get(mrb_state *mrb, htable *t, mrb_value key, mrb_value *vp)
 {
   segindex *index = t->index;
-  size_t mask = SG_MASK(index);
-  size_t k = sg_hash_func(mrb, t, key) & mask;
+  size_t mask = HT_MASK(index);
+  size_t k = ht_hash_func(mrb, t, key) & mask;
   size_t step = 0;
 
   while (index->table[k]) {
     mrb_value key2 = index->table[k]->key;
-    if (!mrb_undef_p(key2) && sg_hash_equal(mrb, t, key, key2)) {
+    if (!mrb_undef_p(key2) && ht_hash_equal(mrb, t, key, key2)) {
       if (vp) *vp = index->table[k]->val;
       return TRUE;
     }
@@ -412,28 +437,28 @@ sg_index_get(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
   return FALSE;
 }
 
-/* Get a value for a key from the segment list. */
+/* Get a value for a key from the hash table. */
 static mrb_bool
-sg_get(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
+ht_get(mrb_state *mrb, htable *t, mrb_value key, mrb_value *vp)
 {
   segment *seg;
   mrb_int i;
 
   if (t == NULL) return FALSE;
   if (t->index) {
-    return sg_index_get(mrb, t, key, vp);
+    return ht_index_get(mrb, t, key, vp);
   }
 
   seg = t->rootseg;
   while (seg) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+    for (i=0; i<seg->size; i++) {
       mrb_value k = seg->e[i].key;
 
       if (!seg->next && i >= t->last_len) {
         return FALSE;
       }
       if (mrb_undef_p(k)) continue;
-      if (sg_hash_equal(mrb, t, k, key)) {
+      if (ht_hash_equal(mrb, t, k, key)) {
         if (vp) *vp = seg->e[i].val;
         return TRUE;
       }
@@ -446,7 +471,7 @@ sg_get(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
 /* Deletes the value for the symbol from the instance variable table. */
 /* Deletion is done by overwriting keys by `undef`. */
 static mrb_bool
-sg_del(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
+ht_del(mrb_state *mrb, htable *t, mrb_value key, mrb_value *vp)
 {
   segment *seg;
   mrb_int i;
@@ -454,7 +479,7 @@ sg_del(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
   if (t == NULL) return FALSE;
   seg = t->rootseg;
   while (seg) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+    for (i=0; i<seg->size; i++) {
       mrb_value key2;
 
       if (!seg->next && i >= t->last_len) {
@@ -462,7 +487,7 @@ sg_del(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
         return FALSE;
       }
       key2 = seg->e[i].key;
-      if (!mrb_undef_p(key2) && sg_hash_equal(mrb, t, key, key2)) {
+      if (!mrb_undef_p(key2) && ht_hash_equal(mrb, t, key, key2)) {
         if (vp) *vp = seg->e[i].val;
         seg->e[i].key = mrb_undef_value();
         t->size--;
@@ -476,18 +501,15 @@ sg_del(mrb_state *mrb, seglist *t, mrb_value key, mrb_value *vp)
 
 /* Iterates over the instance variable table. */
 static void
-sg_foreach(mrb_state *mrb, seglist *t, sg_foreach_func *func, void *p)
+ht_foreach(mrb_state *mrb, htable *t, ht_foreach_func *func, void *p)
 {
   segment *seg;
   mrb_int i;
 
   if (t == NULL) return;
-  if (t->index && t->index->size-(size_t)t->size > MRB_SG_SEGMENT_SIZE) {
-    sg_compact(mrb, t);
-  }
   seg = t->rootseg;
   while (seg) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+    for (i=0; i<seg->size; i++) {
       /* no value in last segment after last_len */
       if (!seg->next && i >= t->last_len) {
         return;
@@ -500,34 +522,26 @@ sg_foreach(mrb_state *mrb, seglist *t, sg_foreach_func *func, void *p)
   }
 }
 
-/* Get the size of the instance variable table. */
-static mrb_int
-sg_size(mrb_state *mrb, seglist *t)
-{
-  if (t == NULL) return 0;
-  return t->size;
-}
-
 /* Copy the instance variable table. */
-static seglist*
-sg_copy(mrb_state *mrb, seglist *t)
+static htable*
+ht_copy(mrb_state *mrb, htable *t)
 {
   segment *seg;
-  seglist *t2;
+  htable *t2;
   mrb_int i;
 
   seg = t->rootseg;
-  t2 = sg_new(mrb);
+  t2 = ht_new(mrb);
 
-  while (seg != NULL) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+  while (seg) {
+    for (i=0; i<seg->size; i++) {
       mrb_value key = seg->e[i].key;
       mrb_value val = seg->e[i].val;
 
       if ((seg->next == NULL) && (i >= t->last_len)) {
         return t2;
       }
-      sg_put(mrb, t2, key, val);
+      ht_put(mrb, t2, key, val);
     }
     seg = seg->next;
   }
@@ -536,7 +550,7 @@ sg_copy(mrb_state *mrb, seglist *t)
 
 /* Free memory of the instance variable table. */
 static void
-sg_free(mrb_state *mrb, seglist *t)
+ht_free(mrb_state *mrb, htable *t)
 {
   segment *seg;
 
@@ -576,20 +590,20 @@ hash_mark_i(mrb_state *mrb, mrb_value key, mrb_value val, void *p)
 void
 mrb_gc_mark_hash(mrb_state *mrb, struct RHash *hash)
 {
-  sg_foreach(mrb, hash->ht, hash_mark_i, NULL);
+  ht_foreach(mrb, hash->ht, hash_mark_i, NULL);
 }
 
 size_t
 mrb_gc_mark_hash_size(mrb_state *mrb, struct RHash *hash)
 {
   if (!hash->ht) return 0;
-  return sg_size(mrb, hash->ht)*2;
+  return hash->ht->size*2;
 }
 
 void
 mrb_gc_free_hash(mrb_state *mrb, struct RHash *hash)
 {
-  sg_free(mrb, hash->ht);
+  ht_free(mrb, hash->ht);
 }
 
 MRB_API mrb_value
@@ -609,8 +623,8 @@ mrb_hash_new_capa(mrb_state *mrb, mrb_int capa)
   struct RHash *h;
 
   h = (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
-  /* preallocate segment list */
-  h->ht = sg_new(mrb);
+  /* preallocate hash table */
+  h->ht = ht_new(mrb);
   /* capacity ignored */
   h->iv = 0;
   return mrb_obj_value(h);
@@ -624,7 +638,7 @@ mrb_hash_init_copy(mrb_state *mrb, mrb_value self)
 {
   mrb_value orig;
   struct RHash* copy;
-  seglist *orig_h;
+  htable *orig_h;
   mrb_value ifnone, vret;
 
   mrb_get_args(mrb, "o", &orig);
@@ -635,7 +649,7 @@ mrb_hash_init_copy(mrb_state *mrb, mrb_value self)
 
   orig_h = RHASH_TBL(self);
   copy = (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
-  copy->ht = sg_copy(mrb, orig_h);
+  copy->ht = ht_copy(mrb, orig_h);
 
   if (MRB_RHASH_DEFAULT_P(self)) {
     copy->flags |= MRB_HASH_DEFAULT;
@@ -663,22 +677,22 @@ check_kdict_i(mrb_state *mrb, mrb_value key, mrb_value val, void *data)
 void
 mrb_hash_check_kdict(mrb_state *mrb, mrb_value self)
 {
-  seglist *sg;
+  htable *t;
 
-  sg = RHASH_TBL(self);
-  if (!sg || sg_size(mrb, sg) == 0) return;
-  sg_foreach(mrb, sg, check_kdict_i, NULL);
+  t = RHASH_TBL(self);
+  if (!t || t->size == 0) return;
+  ht_foreach(mrb, t, check_kdict_i, NULL);
 }
 
 MRB_API mrb_value
 mrb_hash_dup(mrb_state *mrb, mrb_value self)
 {
   struct RHash* copy;
-  seglist *orig_h;
+  htable *orig_h;
 
   orig_h = RHASH_TBL(self);
   copy = (struct RHash*)mrb_obj_alloc(mrb, MRB_TT_HASH, mrb->hash_class);
-  copy->ht = orig_h ? sg_copy(mrb, orig_h) : NULL;
+  copy->ht = orig_h ? ht_copy(mrb, orig_h) : NULL;
   return mrb_obj_value(copy);
 }
 
@@ -688,7 +702,7 @@ mrb_hash_get(mrb_state *mrb, mrb_value hash, mrb_value key)
   mrb_value val;
   mrb_sym mid;
 
-  if (sg_get(mrb, RHASH_TBL(hash), key, &val)) {
+  if (ht_get(mrb, RHASH_TBL(hash), key, &val)) {
     return val;
   }
 
@@ -705,7 +719,7 @@ mrb_hash_fetch(mrb_state *mrb, mrb_value hash, mrb_value key, mrb_value def)
 {
   mrb_value val;
 
-  if (sg_get(mrb, RHASH_TBL(hash), key, &val)) {
+  if (ht_get(mrb, RHASH_TBL(hash), key, &val)) {
     return val;
   }
   /* not found */
@@ -718,22 +732,10 @@ mrb_hash_set(mrb_state *mrb, mrb_value hash, mrb_value key, mrb_value val)
   mrb_hash_modify(mrb, hash);
 
   key = KEY(key);
-  sg_put(mrb, RHASH_TBL(hash), key, val);
+  ht_put(mrb, RHASH_TBL(hash), key, val);
   mrb_field_write_barrier_value(mrb, (struct RBasic*)RHASH(hash), key);
   mrb_field_write_barrier_value(mrb, (struct RBasic*)RHASH(hash), val);
   return;
-}
-
-MRB_API mrb_value
-mrb_ensure_hash_type(mrb_state *mrb, mrb_value hash)
-{
-  return mrb_convert_type(mrb, hash, MRB_TT_HASH, "Hash", "to_hash");
-}
-
-MRB_API mrb_value
-mrb_check_hash_type(mrb_state *mrb, mrb_value hash)
-{
-  return mrb_check_convert_type(mrb, hash, MRB_TT_HASH, "Hash", "to_hash");
 }
 
 static void
@@ -744,7 +746,7 @@ mrb_hash_modify(mrb_state *mrb, mrb_value hash)
   }
 
   if (!RHASH_TBL(hash)) {
-    RHASH_TBL(hash) = sg_new(mrb);
+    RHASH_TBL(hash) = ht_new(mrb);
   }
 }
 
@@ -985,10 +987,10 @@ mrb_hash_set_default_proc(mrb_state *mrb, mrb_value hash)
 MRB_API mrb_value
 mrb_hash_delete_key(mrb_state *mrb, mrb_value hash, mrb_value key)
 {
-  seglist *sg = RHASH_TBL(hash);
+  htable *t = RHASH_TBL(hash);
   mrb_value del_val;
 
-  if (sg_del(mrb, sg, key, &del_val)) {
+  if (ht_del(mrb, t, key, &del_val)) {
     return del_val;
   }
 
@@ -1006,15 +1008,15 @@ mrb_hash_delete(mrb_state *mrb, mrb_value self)
   return mrb_hash_delete_key(mrb, self, key);
 }
 
-/* find first element in segment list, and remove it. */
+/* find first element in a hash table, and remove it. */
 static void
-sg_shift(mrb_state *mrb, seglist *t, mrb_value *kp, mrb_value *vp)
+ht_shift(mrb_state *mrb, htable *t, mrb_value *kp, mrb_value *vp)
 {
   segment *seg = t->rootseg;
   mrb_int i;
 
   while (seg) {
-    for (i=0; i<MRB_SG_SEGMENT_SIZE; i++) {
+    for (i=0; i<seg->size; i++) {
       mrb_value key;
 
       if (!seg->next && i >= t->last_len) {
@@ -1050,13 +1052,15 @@ sg_shift(mrb_state *mrb, seglist *t, mrb_value *kp, mrb_value *vp)
 static mrb_value
 mrb_hash_shift(mrb_state *mrb, mrb_value hash)
 {
-  seglist *sg = RHASH_TBL(hash);
+  htable *t = RHASH_TBL(hash);
 
   mrb_hash_modify(mrb, hash);
-  if (sg && sg_size(mrb, sg) > 0) {
+  if (t && t->size > 0) {
     mrb_value del_key, del_val;
 
-    sg_shift(mrb, sg, &del_key, &del_val);
+    ht_shift(mrb, t, &del_key, &del_val);
+    mrb_gc_protect(mrb, del_key);
+    mrb_gc_protect(mrb, del_val);
     return mrb_assoc_new(mrb, del_key, del_val);
   }
 
@@ -1086,11 +1090,11 @@ mrb_hash_shift(mrb_state *mrb, mrb_value hash)
 MRB_API mrb_value
 mrb_hash_clear(mrb_state *mrb, mrb_value hash)
 {
-  seglist *sg = RHASH_TBL(hash);
+  htable *t = RHASH_TBL(hash);
 
   mrb_hash_modify(mrb, hash);
-  if (sg) {
-    sg_free(mrb, sg);
+  if (t) {
+    ht_free(mrb, t);
     RHASH_TBL(hash) = NULL;
   }
   return hash;
@@ -1142,19 +1146,19 @@ mrb_hash_aset(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_hash_size_m(mrb_state *mrb, mrb_value self)
 {
-  seglist *sg = RHASH_TBL(self);
+  htable *t = RHASH_TBL(self);
 
-  if (!sg) return mrb_fixnum_value(0);
-  return mrb_fixnum_value(sg_size(mrb, sg));
+  if (!t) return mrb_fixnum_value(0);
+  return mrb_fixnum_value(t->size);
 }
 
 MRB_API mrb_bool
 mrb_hash_empty_p(mrb_state *mrb, mrb_value self)
 {
-  seglist *sg = RHASH_TBL(self);
+  htable *t = RHASH_TBL(self);
 
-  if (!sg) return TRUE;
-  return sg_size(mrb, sg) == 0;
+  if (!t) return TRUE;
+  return t->size == 0;
 }
 
 /* 15.2.13.4.12 */
@@ -1171,20 +1175,6 @@ static mrb_value
 mrb_hash_empty_m(mrb_state *mrb, mrb_value self)
 {
   return mrb_bool_value(mrb_hash_empty_p(mrb, self));
-}
-
-/* 15.2.13.4.29 (x)*/
-/*
- * call-seq:
- *    hsh.to_hash   => hsh
- *
- * Returns +self+.
- */
-
-static mrb_value
-mrb_hash_to_hash(mrb_state *mrb, mrb_value hash)
-{
-  return hash;
 }
 
 static int
@@ -1210,14 +1200,14 @@ hash_keys_i(mrb_state *mrb, mrb_value key, mrb_value val, void *p)
 MRB_API mrb_value
 mrb_hash_keys(mrb_state *mrb, mrb_value hash)
 {
-  seglist *sg = RHASH_TBL(hash);
-  size_t size;
+  htable *t = RHASH_TBL(hash);
+  mrb_int size;
   mrb_value ary;
 
-  if (!sg || (size = sg_size(mrb, sg)) == 0)
+  if (!t || (size = t->size) == 0)
     return mrb_ary_new(mrb);
   ary = mrb_ary_new_capa(mrb, size);
-  sg_foreach(mrb, sg, hash_keys_i, (void*)&ary);
+  ht_foreach(mrb, t, hash_keys_i, (void*)&ary);
   return ary;
 }
 
@@ -1244,14 +1234,14 @@ hash_vals_i(mrb_state *mrb, mrb_value key, mrb_value val, void *p)
 MRB_API mrb_value
 mrb_hash_values(mrb_state *mrb, mrb_value hash)
 {
-  seglist *sg = RHASH_TBL(hash);
-  size_t size;
+  htable *t = RHASH_TBL(hash);
+  mrb_int size;
   mrb_value ary;
 
-  if (!sg || (size = sg_size(mrb, sg)) == 0)
+  if (!t || (size = t->size) == 0)
     return mrb_ary_new(mrb);
   ary = mrb_ary_new_capa(mrb, size);
-  sg_foreach(mrb, sg, hash_vals_i, (void*)&ary);
+  ht_foreach(mrb, t, hash_vals_i, (void*)&ary);
   return ary;
 }
 
@@ -1277,10 +1267,10 @@ mrb_hash_values(mrb_state *mrb, mrb_value hash)
 MRB_API mrb_bool
 mrb_hash_key_p(mrb_state *mrb, mrb_value hash, mrb_value key)
 {
-  seglist *sg;
+  htable *t;
 
-  sg = RHASH_TBL(hash);
-  if (sg_get(mrb, sg, key, NULL)) {
+  t = RHASH_TBL(hash);
+  if (ht_get(mrb, t, key, NULL)) {
     return TRUE;
   }
   return FALSE;
@@ -1338,23 +1328,23 @@ mrb_hash_has_value(mrb_state *mrb, mrb_value hash)
   mrb_get_args(mrb, "o", &val);
   arg.found = FALSE;
   arg.val = val;
-  sg_foreach(mrb, RHASH_TBL(hash), hash_has_value_i, &arg);
+  ht_foreach(mrb, RHASH_TBL(hash), hash_has_value_i, &arg);
   return mrb_bool_value(arg.found);
 }
 
 static int
 merge_i(mrb_state *mrb, mrb_value key, mrb_value val, void *data)
 {
-  seglist *h1 = (seglist*)data;
+  htable *h1 = (htable*)data;
 
-  sg_put(mrb, h1, key, val);
+  ht_put(mrb, h1, key, val);
   return 0;
 }
 
 MRB_API void
 mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2)
 {
-  seglist *h1, *h2;
+  htable *h1, *h2;
 
   mrb_hash_modify(mrb, hash1);
   hash2 = mrb_ensure_hash_type(mrb, hash2);
@@ -1363,10 +1353,10 @@ mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2)
 
   if (!h2) return;
   if (!h1) {
-    RHASH_TBL(hash1) = sg_copy(mrb, h2);
+    RHASH_TBL(hash1) = ht_copy(mrb, h2);
     return;
   }
-  sg_foreach(mrb, h2, merge_i, h1);
+  ht_foreach(mrb, h2, merge_i, h1);
   mrb_write_barrier(mrb, (struct RBasic*)RHASH(hash1));
   return;
 }
@@ -1387,7 +1377,7 @@ mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2)
 static mrb_value
 mrb_hash_rehash(mrb_state *mrb, mrb_value self)
 {
-  sg_compact(mrb, RHASH_TBL(self));
+  ht_compact(mrb, RHASH_TBL(self));
   return self;
 }
 
@@ -1423,6 +1413,4 @@ mrb_init_hash(mrb_state *mrb)
   mrb_define_method(mrb, h, "value?",          mrb_hash_has_value,   MRB_ARGS_REQ(1)); /* 15.2.13.4.27 */
   mrb_define_method(mrb, h, "values",          mrb_hash_values,      MRB_ARGS_NONE()); /* 15.2.13.4.28 */
   mrb_define_method(mrb, h, "rehash",          mrb_hash_rehash,      MRB_ARGS_NONE());
-
-  mrb_define_method(mrb, h, "to_hash",         mrb_hash_to_hash,     MRB_ARGS_NONE()); /* 15.2.13.4.29 (x)*/
 }

--- a/mruby/src/kernel.c
+++ b/mruby/src/kernel.c
@@ -746,6 +746,7 @@ basic_obj_respond_to(mrb_state *mrb, mrb_value obj, mrb_sym id, int pub)
 {
   return mrb_respond_to(mrb, obj, id);
 }
+
 /* 15.3.1.3.43 */
 /*
  *  call-seq:
@@ -765,45 +766,16 @@ basic_obj_respond_to(mrb_state *mrb, mrb_value obj, mrb_sym id, int pub)
 static mrb_value
 obj_respond_to(mrb_state *mrb, mrb_value self)
 {
-  mrb_value mid;
   mrb_sym id, rtm_id;
-  mrb_bool priv = FALSE, respond_to_p = TRUE;
+  mrb_bool priv = FALSE, respond_to_p;
 
-  mrb_get_args(mrb, "o|b", &mid, &priv);
-
-  if (mrb_symbol_p(mid)) {
-    id = mrb_symbol(mid);
-  }
-  else {
-    mrb_value tmp;
-    if (mrb_string_p(mid)) {
-      tmp = mrb_check_intern_str(mrb, mid);
-    }
-    else {
-      tmp = mrb_check_string_type(mrb, mid);
-      if (mrb_nil_p(tmp)) {
-        tmp = mrb_inspect(mrb, mid);
-        mrb_raisef(mrb, E_TYPE_ERROR, "%S is not a symbol", tmp);
-      }
-      tmp = mrb_check_intern_str(mrb, tmp);
-    }
-    if (mrb_nil_p(tmp)) {
-      respond_to_p = FALSE;
-    }
-    else {
-      id = mrb_symbol(tmp);
-    }
-  }
-
-  if (respond_to_p) {
-    respond_to_p = basic_obj_respond_to(mrb, self, id, !priv);
-  }
-
+  mrb_get_args(mrb, "n|b", &id, &priv);
+  respond_to_p = basic_obj_respond_to(mrb, self, id, !priv);
   if (!respond_to_p) {
     rtm_id = mrb_intern_lit(mrb, "respond_to_missing?");
     if (basic_obj_respond_to(mrb, self, rtm_id, !priv)) {
       mrb_value args[2], v;
-      args[0] = mid;
+      args[0] = mrb_symbol_value(id);
       args[1] = mrb_bool_value(priv);
       v = mrb_funcall_argv(mrb, self, rtm_id, 2, args);
       return mrb_bool_value(mrb_bool(v));
@@ -830,6 +802,7 @@ mrb_obj_ceqq(mrb_state *mrb, mrb_value self)
 }
 
 mrb_value mrb_obj_equal_m(mrb_state *mrb, mrb_value);
+
 void
 mrb_init_kernel(mrb_state *mrb)
 {
@@ -871,6 +844,8 @@ mrb_init_kernel(mrb_state *mrb)
   mrb_define_method(mrb, krn, "respond_to?",                obj_respond_to,                  MRB_ARGS_ANY());     /* 15.3.1.3.43 */
   mrb_define_method(mrb, krn, "to_s",                       mrb_any_to_s,                    MRB_ARGS_NONE());    /* 15.3.1.3.46 */
   mrb_define_method(mrb, krn, "__case_eqq",                 mrb_obj_ceqq,                    MRB_ARGS_REQ(1));    /* internal */
+  mrb_define_method(mrb, krn, "__to_int",                   mrb_to_int,                      MRB_ARGS_NONE()); /* internal */
+  mrb_define_method(mrb, krn, "__to_str",                   mrb_to_str,                      MRB_ARGS_NONE()); /* internal */
 
   mrb_define_method(mrb, krn, "class_defined?",             mrb_krn_class_defined,           MRB_ARGS_REQ(1));
 

--- a/mruby/src/load.c
+++ b/mruby/src/load.c
@@ -215,12 +215,11 @@ read_section_irep(mrb_state *mrb, const uint8_t *bin, uint8_t flags)
   return read_irep_record(mrb, bin, &len, flags);
 }
 
+/* ignore lineno record */
 static int
 read_lineno_record_1(mrb_state *mrb, const uint8_t *bin, mrb_irep *irep, size_t *len)
 {
   size_t i, fname_len, niseq;
-  char *fname;
-  uint16_t *lines;
 
   *len = 0;
   bin += sizeof(uint32_t); /* record size */
@@ -228,9 +227,6 @@ read_lineno_record_1(mrb_state *mrb, const uint8_t *bin, mrb_irep *irep, size_t 
   fname_len = bin_to_uint16(bin);
   bin += sizeof(uint16_t);
   *len += sizeof(uint16_t);
-  fname = (char *)mrb_malloc(mrb, fname_len + 1);
-  memcpy(fname, bin, fname_len);
-  fname[fname_len] = '\0';
   bin += fname_len;
   *len += fname_len;
 
@@ -241,15 +237,11 @@ read_lineno_record_1(mrb_state *mrb, const uint8_t *bin, mrb_irep *irep, size_t 
   if (SIZE_ERROR_MUL(niseq, sizeof(uint16_t))) {
     return MRB_DUMP_GENERAL_FAILURE;
   }
-  lines = (uint16_t *)mrb_malloc(mrb, niseq * sizeof(uint16_t));
   for (i = 0; i < niseq; i++) {
-    lines[i] = bin_to_uint16(bin);
     bin += sizeof(uint16_t); /* niseq */
     *len += sizeof(uint16_t);
   }
 
-  irep->filename = fname;
-  irep->lines = lines;
   return MRB_DUMP_OK;
 }
 

--- a/mruby/src/numeric.c
+++ b/mruby/src/numeric.c
@@ -674,7 +674,6 @@ flo_round(mrb_state *mrb, mrb_value num)
 /*
  *  call-seq:
  *     flt.to_i      ->  integer
- *     flt.to_int    ->  integer
  *     flt.truncate  ->  integer
  *
  *  Returns <i>flt</i> truncated to an <code>Integer</code>.
@@ -714,7 +713,6 @@ flo_nan_p(mrb_state *mrb, mrb_value num)
 /*
  *  call-seq:
  *     int.to_i      ->  integer
- *     int.to_int    ->  integer
  *
  *  As <i>int</i> is already an <code>Integer</code>, all these
  *  methods simply return the receiver.
@@ -1513,7 +1511,6 @@ mrb_init_numeric(mrb_state *mrb)
   MRB_SET_INSTANCE_TT(integer, MRB_TT_FIXNUM);
   mrb_undef_class_method(mrb, integer, "new");
   mrb_define_method(mrb, integer, "to_i",     int_to_i,        MRB_ARGS_NONE()); /* 15.2.8.3.24 */
-  mrb_define_method(mrb, integer, "to_int",   int_to_i,        MRB_ARGS_NONE());
 #ifndef MRB_WITHOUT_FLOAT
   mrb_define_method(mrb, integer, "ceil",     int_to_i,        MRB_ARGS_REQ(1)); /* 15.2.8.3.8 (x) */
   mrb_define_method(mrb, integer, "floor",    int_to_i,        MRB_ARGS_REQ(1)); /* 15.2.8.3.10 (x) */
@@ -1565,7 +1562,6 @@ mrb_init_numeric(mrb_state *mrb)
   mrb_define_method(mrb, fl,      "round",     flo_round,      MRB_ARGS_OPT(1)); /* 15.2.9.3.12 */
   mrb_define_method(mrb, fl,      "to_f",      flo_to_f,       MRB_ARGS_NONE()); /* 15.2.9.3.13 */
   mrb_define_method(mrb, fl,      "to_i",      flo_truncate,   MRB_ARGS_NONE()); /* 15.2.9.3.14 */
-  mrb_define_method(mrb, fl,      "to_int",    flo_truncate,   MRB_ARGS_NONE());
   mrb_define_method(mrb, fl,      "truncate",  flo_truncate,   MRB_ARGS_NONE()); /* 15.2.9.3.15 */
   mrb_define_method(mrb, fl,      "divmod",    flo_divmod,     MRB_ARGS_REQ(1));
   mrb_define_method(mrb, fl,      "eql?",      flo_eql,        MRB_ARGS_REQ(1)); /* 15.2.8.3.16 */

--- a/mruby/src/object.c
+++ b/mruby/src/object.c
@@ -323,19 +323,6 @@ convert_type(mrb_state *mrb, mrb_value val, const char *tname, const char *metho
 }
 
 MRB_API mrb_value
-mrb_check_to_integer(mrb_state *mrb, mrb_value val, const char *method)
-{
-  mrb_value v;
-
-  if (mrb_fixnum_p(val)) return val;
-  v = convert_type(mrb, val, "Integer", method, FALSE);
-  if (mrb_nil_p(v) || !mrb_fixnum_p(v)) {
-    return mrb_nil_value();
-  }
-  return v;
-}
-
-MRB_API mrb_value
 mrb_convert_type(mrb_state *mrb, mrb_value val, enum mrb_vtype type, const char *tname, const char *method)
 {
   mrb_value v;
@@ -505,25 +492,22 @@ mrb_obj_is_kind_of(mrb_state *mrb, mrb_value obj, struct RClass *c)
   return FALSE;
 }
 
-static mrb_value
-mrb_to_integer(mrb_state *mrb, mrb_value val, const char *method)
-{
-  mrb_value v;
-
-  if (mrb_fixnum_p(val)) return val;
-  v = convert_type(mrb, val, "Integer", method, TRUE);
-  if (!mrb_obj_is_kind_of(mrb, v, mrb->fixnum_class)) {
-    mrb_value type = inspect_type(mrb, val);
-    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S to Integer (%S#%S gives %S)",
-               type, type, mrb_str_new_cstr(mrb, method), inspect_type(mrb, v));
-  }
-  return v;
-}
-
 MRB_API mrb_value
 mrb_to_int(mrb_state *mrb, mrb_value val)
 {
-  return mrb_to_integer(mrb, val, "to_int");
+
+  if (!mrb_fixnum_p(val)) {
+    mrb_value type;
+
+#ifndef MRB_WITHOUT_FLOAT
+    if (mrb_float_p(val)) {
+      return mrb_flo_to_fixnum(mrb, val);
+    }
+#endif
+    type = inspect_type(mrb, val);
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S to Integer", type);
+  }
+  return val;
 }
 
 MRB_API mrb_value
@@ -533,18 +517,12 @@ mrb_convert_to_integer(mrb_state *mrb, mrb_value val, mrb_int base)
 
   if (mrb_nil_p(val)) {
     if (base != 0) goto arg_error;
-      mrb_raise(mrb, E_TYPE_ERROR, "can't convert nil into Integer");
+    mrb_raise(mrb, E_TYPE_ERROR, "can't convert nil into Integer");
   }
   switch (mrb_type(val)) {
 #ifndef MRB_WITHOUT_FLOAT
     case MRB_TT_FLOAT:
       if (base != 0) goto arg_error;
-      else {
-        mrb_float f = mrb_float(val);
-        if (FIXABLE_FLOAT(f)) {
-          break;
-        }
-      }
       return mrb_flo_to_fixnum(mrb, val);
 #endif
 
@@ -568,11 +546,8 @@ mrb_convert_to_integer(mrb_state *mrb, mrb_value val, mrb_int base)
 arg_error:
     mrb_raise(mrb, E_ARGUMENT_ERROR, "base specified for non string value");
   }
-  tmp = convert_type(mrb, val, "Integer", "to_int", FALSE);
-  if (mrb_nil_p(tmp) || !mrb_fixnum_p(tmp)) {
-    tmp = mrb_to_integer(mrb, val, "to_i");
-  }
-  return tmp;
+  /* to raise TypeError */
+  return mrb_to_int(mrb, val);
 }
 
 MRB_API mrb_value
@@ -603,6 +578,74 @@ mrb_Float(mrb_state *mrb, mrb_value val)
   }
 }
 #endif
+
+MRB_API mrb_value
+mrb_to_str(mrb_state *mrb, mrb_value val)
+{
+  if (!mrb_string_p(val)) {
+    mrb_value type = inspect_type(mrb, val);
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S to String", type);
+  }
+  return val;
+}
+
+/* obsolete: use mrb_ensure_string_type() instead */
+MRB_API mrb_value
+mrb_string_type(mrb_state *mrb, mrb_value str)
+{
+  return mrb_ensure_string_type(mrb, str);
+}
+
+MRB_API mrb_value
+mrb_ensure_string_type(mrb_state *mrb, mrb_value str)
+{
+  if (!mrb_string_p(str)) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "%S cannot be converted to String",
+               inspect_type(mrb, str));
+  }
+  return str;
+}
+
+MRB_API mrb_value
+mrb_check_string_type(mrb_state *mrb, mrb_value str)
+{
+  if (!mrb_string_p(str)) return mrb_nil_value();
+  return str;
+}
+
+MRB_API mrb_value
+mrb_ensure_array_type(mrb_state *mrb, mrb_value ary)
+{
+  if (!mrb_array_p(ary)) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "%S cannot be converted to Array",
+               inspect_type(mrb, ary));
+  }
+  return ary;
+}
+
+MRB_API mrb_value
+mrb_check_array_type(mrb_state *mrb, mrb_value ary)
+{
+  if (!mrb_array_p(ary)) return mrb_nil_value();
+  return ary;
+}
+
+MRB_API mrb_value
+mrb_ensure_hash_type(mrb_state *mrb, mrb_value hash)
+{
+  if (!mrb_hash_p(hash)) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "%S cannot be converted to Hash",
+               inspect_type(mrb, hash));
+  }
+  return hash;
+}
+
+MRB_API mrb_value
+mrb_check_hash_type(mrb_state *mrb, mrb_value hash)
+{
+  if (!mrb_hash_p(hash)) return mrb_nil_value();
+  return hash;
+}
 
 MRB_API mrb_value
 mrb_inspect(mrb_state *mrb, mrb_value obj)

--- a/mruby/src/state.c
+++ b/mruby/src/state.c
@@ -168,10 +168,6 @@ mrb_irep_free(mrb_state *mrb, mrb_irep *irep)
   }
   mrb_free(mrb, irep->reps);
   mrb_free(mrb, irep->lv);
-  if (irep->own_filename) {
-    mrb_free(mrb, (void *)irep->filename);
-  }
-  mrb_free(mrb, irep->lines);
   mrb_debug_info_free(mrb, irep->debug_info);
   mrb_free(mrb, irep);
 }
@@ -273,7 +269,6 @@ mrb_add_irep(mrb_state *mrb)
   irep = (mrb_irep *)mrb_malloc(mrb, sizeof(mrb_irep));
   *irep = mrb_irep_zero;
   irep->refcnt = 1;
-  irep->own_filename = FALSE;
 
   return irep;
 }

--- a/mruby/src/string.c
+++ b/mruby/src/string.c
@@ -748,9 +748,7 @@ mrb_str_to_cstr(mrb_state *mrb, mrb_value str0)
 MRB_API void
 mrb_str_concat(mrb_state *mrb, mrb_value self, mrb_value other)
 {
-  if (!mrb_string_p(other)) {
-    other = mrb_str_to_str(mrb, other);
-  }
+  other = mrb_str_to_str(mrb, other);
   mrb_str_cat_str(mrb, self, other);
 }
 
@@ -956,15 +954,7 @@ str_eql(mrb_state *mrb, const mrb_value str1, const mrb_value str2)
 MRB_API mrb_bool
 mrb_str_equal(mrb_state *mrb, mrb_value str1, mrb_value str2)
 {
-  if (mrb_immediate_p(str2)) return FALSE;
-  if (!mrb_string_p(str2)) {
-    if (mrb_nil_p(str2)) return FALSE;
-    if (!mrb_respond_to(mrb, str2, mrb_intern_lit(mrb, "to_str"))) {
-      return FALSE;
-    }
-    str2 = mrb_funcall(mrb, str2, "to_str", 0);
-    return mrb_equal(mrb, str2, str1);
-  }
+  if (!mrb_string_p(str2)) return FALSE;
   return str_eql(mrb, str1, str2);
 }
 
@@ -992,30 +982,24 @@ mrb_str_equal_m(mrb_state *mrb, mrb_value str1)
 MRB_API mrb_value
 mrb_str_to_str(mrb_state *mrb, mrb_value str)
 {
-  mrb_value s;
-
   if (!mrb_string_p(str)) {
-    s = mrb_check_convert_type(mrb, str, MRB_TT_STRING, "String", "to_str");
-    if (mrb_nil_p(s)) {
-      s = mrb_convert_type(mrb, str, MRB_TT_STRING, "String", "to_s");
-    }
-    return s;
+    return mrb_convert_type(mrb, str, MRB_TT_STRING, "String", "to_s");
   }
   return str;
 }
 
 MRB_API const char*
-mrb_string_value_ptr(mrb_state *mrb, mrb_value ptr)
+mrb_string_value_ptr(mrb_state *mrb, mrb_value str)
 {
-  mrb_value str = mrb_str_to_str(mrb, ptr);
+  str = mrb_str_to_str(mrb, str);
   return RSTRING_PTR(str);
 }
 
 MRB_API mrb_int
 mrb_string_value_len(mrb_state *mrb, mrb_value ptr)
 {
-  mrb_value str = mrb_str_to_str(mrb, ptr);
-  return RSTRING_LEN(str);
+  mrb_to_str(mrb, ptr);
+  return RSTRING_LEN(ptr);
 }
 
 void
@@ -1714,18 +1698,6 @@ mrb_ptr_to_str(mrb_state *mrb, void *p)
   return mrb_obj_value(p_str);
 }
 
-MRB_API mrb_value
-mrb_string_type(mrb_state *mrb, mrb_value str)
-{
-  return mrb_convert_type(mrb, str, MRB_TT_STRING, "String", "to_str");
-}
-
-MRB_API mrb_value
-mrb_check_string_type(mrb_state *mrb, mrb_value str)
-{
-  return mrb_check_convert_type(mrb, str, MRB_TT_STRING, "String", "to_str");
-}
-
 /* 15.2.10.5.30 */
 /*
  *  call-seq:
@@ -2209,7 +2181,7 @@ mrb_cstr_to_inum(mrb_state *mrb, const char *str, int base, int badcheck)
 MRB_API const char*
 mrb_string_value_cstr(mrb_state *mrb, mrb_value *ptr)
 {
-  mrb_value str = mrb_str_to_str(mrb, *ptr);
+  mrb_value str = mrb_to_str(mrb, *ptr);
   struct RString *ps = mrb_str_ptr(str);
   mrb_int len = mrb_str_strlen(mrb, ps);
   char *p = RSTR_PTR(ps);
@@ -2339,7 +2311,7 @@ mrb_str_to_dbl(mrb_state *mrb, mrb_value str, mrb_bool badcheck)
   char *s;
   mrb_int len;
 
-  str = mrb_str_to_str(mrb, str);
+  mrb_to_str(mrb, str);
   s = RSTRING_PTR(str);
   len = RSTRING_LEN(str);
   if (s) {
@@ -2379,7 +2351,6 @@ mrb_str_to_f(mrb_state *mrb, mrb_value self)
 /*
  *  call-seq:
  *     str.to_s     => str
- *     str.to_str   => str
  *
  *  Returns the receiver.
  */
@@ -2627,7 +2598,7 @@ mrb_str_cat_str(mrb_state *mrb, mrb_value str, mrb_value str2)
 MRB_API mrb_value
 mrb_str_append(mrb_state *mrb, mrb_value str1, mrb_value str2)
 {
-  str2 = mrb_str_to_str(mrb, str2);
+  mrb_to_str(mrb, str2);
   return mrb_str_cat_str(mrb, str1, str2);
 }
 
@@ -2783,7 +2754,6 @@ mrb_init_string(mrb_state *mrb)
 #endif
   mrb_define_method(mrb, s, "to_i",            mrb_str_to_i,            MRB_ARGS_ANY());  /* 15.2.10.5.39 */
   mrb_define_method(mrb, s, "to_s",            mrb_str_to_s,            MRB_ARGS_NONE()); /* 15.2.10.5.40 */
-  mrb_define_method(mrb, s, "to_str",          mrb_str_to_s,            MRB_ARGS_NONE());
   mrb_define_method(mrb, s, "to_sym",          mrb_str_intern,          MRB_ARGS_NONE()); /* 15.2.10.5.41 */
   mrb_define_method(mrb, s, "upcase",          mrb_str_upcase,          MRB_ARGS_NONE()); /* 15.2.10.5.42 */
   mrb_define_method(mrb, s, "upcase!",         mrb_str_upcase_bang,     MRB_ARGS_NONE()); /* 15.2.10.5.43 */

--- a/mruby/src/vm.c
+++ b/mruby/src/vm.c
@@ -55,7 +55,7 @@ void abort(void);
 
 /* Maximum depth of ecall() recursion. */
 #ifndef MRB_ECALL_DEPTH_MAX
-#define MRB_ECALL_DEPTH_MAX 32
+#define MRB_ECALL_DEPTH_MAX 512
 #endif
 
 /* Maximum stack depth. Should be set lower on memory constrained systems.
@@ -337,7 +337,8 @@ ecall(mrb_state *mrb)
   int nregs;
 
   if (i<0) return;
-  if (ci - c->cibase > MRB_ECALL_DEPTH_MAX) {
+  /* restrict total call depth of ecall() */
+  if (++mrb->ecall_nest > MRB_ECALL_DEPTH_MAX) {
     mrb_exc_raise(mrb, mrb_obj_value(mrb->stack_err));
   }
   p = c->ensure[i];
@@ -364,11 +365,15 @@ ecall(mrb_state *mrb)
   if (exc) {
     mrb_gc_protect(mrb, mrb_obj_value(exc));
   }
+  if (mrb->c->fib) {
+    mrb_gc_protect(mrb, mrb_obj_value(mrb->c->fib));
+  }
   mrb_run(mrb, p, env->stack[0]);
   mrb->c = c;
   c->ci = c->cibase + cioff;
   if (!mrb->exc) mrb->exc = exc;
   mrb_gc_arena_restore(mrb, ai);
+  mrb->ecall_nest--;
 }
 
 #ifndef MRB_FUNCALL_ARGC_MAX
@@ -913,8 +918,8 @@ argnum_error(mrb_state *mrb, mrb_int num)
   mrb_exc_set(mrb, exc);
 }
 
-#define ERR_PC_SET(mrb, pc) mrb->c->ci->err = pc;
-#define ERR_PC_CLR(mrb)     mrb->c->ci->err = 0;
+#define ERR_PC_SET(mrb) mrb->c->ci->err = pc0;
+#define ERR_PC_CLR(mrb) mrb->c->ci->err = 0;
 #ifdef MRB_ENABLE_DEBUG_HOOK
 #define CODE_FETCH_HOOK(mrb, irep, pc, regs) if ((mrb)->code_fetch_hook) (mrb)->code_fetch_hook((mrb), (irep), (pc), (regs));
 #else
@@ -936,7 +941,7 @@ argnum_error(mrb_state *mrb, mrb_int num)
 #ifndef DIRECT_THREADED
 
 #define INIT_DISPATCH for (;;) { insn = BYTECODE_DECODER(*pc); CODE_FETCH_HOOK(mrb, irep, pc, regs); switch (insn) {
-#define CASE(insn,ops) case insn: pc++; FETCH_ ## ops ();; L_ ## insn ## _BODY:
+#define CASE(insn,ops) case insn: pc0=pc++; FETCH_ ## ops ();; L_ ## insn ## _BODY:
 #define NEXT break
 #define JUMP NEXT
 #define END_DISPATCH }}
@@ -944,7 +949,7 @@ argnum_error(mrb_state *mrb, mrb_int num)
 #else
 
 #define INIT_DISPATCH JUMP; return mrb_nil_value();
-#define CASE(insn,ops) L_ ## insn: pc++; FETCH_ ## ops (); L_ ## insn ## _BODY:
+#define CASE(insn,ops) L_ ## insn: pc0=pc++; FETCH_ ## ops (); L_ ## insn ## _BODY:
 #define NEXT insn=BYTECODE_DECODER(*pc); CODE_FETCH_HOOK(mrb, irep, pc, regs); goto *optable[insn]
 #define JUMP NEXT
 
@@ -970,14 +975,14 @@ mrb_vm_run(mrb_state *mrb, struct RProc *proc, mrb_value self, unsigned int stac
   stack_clear(c->stack + stack_keep, nregs - stack_keep);
   c->stack[0] = self;
   result = mrb_vm_exec(mrb, proc, irep->iseq);
-  if (c->ci - c->cibase > cioff) {
-    c->ci = c->cibase + cioff;
-  }
   if (mrb->c != c) {
     if (mrb->c->fib) {
       mrb_write_barrier(mrb, (struct RBasic*)mrb->c->fib);
     }
     mrb->c = c;
+  }
+  else if (c->ci - c->cibase > cioff) {
+    c->ci = c->cibase + cioff;
   }
   return result;
 }
@@ -999,6 +1004,7 @@ MRB_API mrb_value
 mrb_vm_exec(mrb_state *mrb, struct RProc *proc, mrb_code *pc)
 {
   /* mrb_assert(mrb_proc_cfunc_p(proc)) */
+  mrb_code *pc0 = pc;
   mrb_irep *irep = proc->body.irep;
   mrb_value *pool = irep->pool;
   mrb_sym *syms = irep->syms;
@@ -1144,7 +1150,7 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_GETCV, BB) {
       mrb_value val;
-      ERR_PC_SET(mrb, pc);
+      ERR_PC_SET(mrb);
       val = mrb_vm_cv_get(mrb, syms[b]);
       ERR_PC_CLR(mrb);
       regs[a] = val;
@@ -1160,7 +1166,7 @@ RETRY_TRY_BLOCK:
       mrb_value val;
       mrb_sym sym = syms[b];
 
-      ERR_PC_SET(mrb, pc);
+      ERR_PC_SET(mrb);
       val = mrb_vm_const_get(mrb, sym);
       ERR_PC_CLR(mrb);
       regs[a] = val;
@@ -1175,7 +1181,7 @@ RETRY_TRY_BLOCK:
     CASE(OP_GETMCNST, BB) {
       mrb_value val;
 
-      ERR_PC_SET(mrb, pc);
+      ERR_PC_SET(mrb);
       val = mrb_const_get(mrb, regs[a], syms[b]);
       ERR_PC_CLR(mrb);
       regs[a] = val;
@@ -1424,7 +1430,7 @@ RETRY_TRY_BLOCK:
         m = mrb_method_search_vm(mrb, &cls, missing);
         if (MRB_METHOD_UNDEF_P(m) || (missing == mrb->c->ci->mid && mrb_obj_eq(mrb, regs[0], recv))) {
           mrb_value args = (argc < 0) ? regs[a+1] : mrb_ary_new_from_values(mrb, c, regs+a+1);
-          ERR_PC_SET(mrb, pc);
+          ERR_PC_SET(mrb);
           mrb_method_missing(mrb, mid, recv, args);
         }
         if (argc >= 0) {
@@ -1621,7 +1627,7 @@ RETRY_TRY_BLOCK:
         m = mrb_method_search_vm(mrb, &cls, missing);
         if (MRB_METHOD_UNDEF_P(m)) {
           mrb_value args = (argc < 0) ? regs[a+1] : mrb_ary_new_from_values(mrb, b, regs+a+1);
-          ERR_PC_SET(mrb, pc);
+          ERR_PC_SET(mrb);
           mrb_method_missing(mrb, mid, recv, args);
         }
         mid = missing;
@@ -1780,11 +1786,9 @@ RETRY_TRY_BLOCK:
 
       /* strict argument check */
       if (mrb->c->ci->proc && MRB_PROC_STRICT_P(mrb->c->ci->proc)) {
-        if (argc >= 0 && !(argc <= 1 && kd)) {
-          if (argc < m1 + m2 + kd || (r == 0 && argc > len + kd)) {
-            argnum_error(mrb, m1+m2);
-            goto L_RAISE;
-          }
+        if (argc < m1 + m2 || (r == 0 && argc > len + kd)) {
+          argnum_error(mrb, m1+m2);
+          goto L_RAISE;
         }
       }
       /* extract first argument array to arguments */
@@ -1805,13 +1809,12 @@ RETRY_TRY_BLOCK:
             kdict = argv[argc-1];
             mrb_hash_check_kdict(mrb, kdict);
           }
-          else if (r) {
+          else if (r || argc <= m1+m2+o) {
             kdict = mrb_hash_new(mrb);
             kargs = 0;
           }
           else {
-            mrb_value str = mrb_str_new_lit(mrb, "Excepcted `Hash` as last argument for keyword arguments");
-            mrb_exc_set(mrb, mrb_exc_new_str(mrb, E_ARGUMENT_ERROR, str));
+            argnum_error(mrb, m1+m2);
             goto L_RAISE;
           }
           if (MRB_ASPEC_KEY(a) > 0) {
@@ -1891,7 +1894,7 @@ RETRY_TRY_BLOCK:
       mrb_value k = mrb_symbol_value(syms[b]);
       mrb_value kdict = regs[mrb->c->ci->argc];
 
-      if (!mrb_hash_key_p(mrb, kdict, k)) {
+      if (!mrb_hash_p(kdict) || !mrb_hash_key_p(mrb, kdict, k)) {
         mrb_value str = mrb_format(mrb, "missing keyword: %S", k);
         mrb_exc_set(mrb, mrb_exc_new_str(mrb, E_ARGUMENT_ERROR, str));
         goto L_RAISE;
@@ -1904,8 +1907,11 @@ RETRY_TRY_BLOCK:
     CASE(OP_KEY_P, BB) {
       mrb_value k = mrb_symbol_value(syms[b]);
       mrb_value kdict = regs[mrb->c->ci->argc];
-      mrb_bool key_p = mrb_hash_key_p(mrb, kdict, k);
+      mrb_bool key_p = FALSE;
 
+      if (mrb_hash_p(kdict)) {
+        key_p = mrb_hash_key_p(mrb, kdict, k);
+      }
       regs[a] = mrb_bool_value(key_p);
       NEXT;
     }
@@ -2928,7 +2934,7 @@ RETRY_TRY_BLOCK:
       mrb_value exc;
 
       exc = mrb_exc_new_str(mrb, E_LOCALJUMP_ERROR, msg);
-      ERR_PC_SET(mrb, pc);
+      ERR_PC_SET(mrb);
       mrb_exc_set(mrb, exc);
       goto L_RAISE;
     }

--- a/mruby/test/t/string.rb
+++ b/mruby/test/t/string.rb
@@ -253,19 +253,6 @@ assert('String#chomp!', '15.2.10.5.10') do
   assert_equal 'abc', e
 end
 
-assert('String#chomp! uses the correct length') do
-  class A
-    def to_str
-      $s.replace("AA")
-      "A"
-    end
-  end
-
-  $s = "AAA"
-  $s.chomp!(A.new)
-  assert_equal $s, "A"
-end
-
 assert('String#chop', '15.2.10.5.11') do
   a = ''.chop
   b = 'abc'.chop

--- a/mruby/test/t/syntax.rb
+++ b/mruby/test/t/syntax.rb
@@ -471,6 +471,10 @@ this is a comment that has extra after =begin and =end with tabs after it
 end
 
 assert 'keyword arguments' do
+  def m(a, b:1) [a, b] end
+  assert_equal [1, 1], m(1)
+  assert_equal [1, 2], m(1, b: 2)
+
   def m(a, b:) [a, b] end
   assert_equal [1, 2], m(1, b: 2)
   assert_raise(ArgumentError) { m b: 1 }

--- a/mruby/travis_config.rb
+++ b/mruby/travis_config.rb
@@ -40,7 +40,7 @@ MRuby::Build.new('cxx_abi') do |conf|
   toolchain :gcc
 
   conf.gembox 'full-core'
-  conf.cc.flags += %w(-Werror=declaration-after-statement)
+  conf.cc.flags += %w(-Werror=declaration-after-statement -fpermissive)
   conf.compilers.each do |c|
     c.defines += %w(MRB_GC_FIXED_ARENA)
   end


### PR DESCRIPTION
mruby 2.0.0 is released today.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
