### PR TITLE
Clear private key when authentication failed

### DIFF
--- a/mrbgems/auto-ssl/mrblib/mrb_auto_ssl_client.rb
+++ b/mrbgems/auto-ssl/mrblib/mrb_auto_ssl_client.rb
@@ -43,6 +43,7 @@ class Nginx
         def clear
           @redis.del("#{@domain}_token_value")
           @redis.del("#{@domain}_authorization_uri")
+          @redis.del("#{@domain}_private_key")
         end
 
         def auto_cert_deploy

--- a/mrbgems/auto-ssl/mrblib/mrb_auto_ssl_client.rb
+++ b/mrbgems/auto-ssl/mrblib/mrb_auto_ssl_client.rb
@@ -69,13 +69,12 @@ class Nginx
               csr = Acme::Client::CertificateRequest.new([@domain])
               begin
                 certificate = client.new_certificate(csr)
+                @redis.set("#{@domain}.crt", certificate.fullchain_to_pem)
+                @redis.set("#{@domain}.key", certificate.request.private_key.to_pem)
               rescue => e
                 Nginx::SSL.log ::Nginx::LOG_ERR, e.message
                 clear
               end
-
-              @redis.set("#{@domain}.crt", certificate.fullchain_to_pem)
-              @redis.set("#{@domain}.key", certificate.request.private_key.to_pem)
             end
           end
         end


### PR DESCRIPTION
## Pull-Request Check List
When running fast cert, you need to remove the key before retrying.


- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
