### PR TITLE
Use pkill on CentOS. killall isn't installed by default.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -20,8 +20,13 @@ else
     NPROCESSORS_ONLN="_NPROCESSORS_ONLN"
     NGINX_DEFAULT_OPT='--with-debug --with-http_stub_status_module --with-http_ssl_module --with-cc-opt=-g\ -O0'
     MAKE=make
-    KILLALL=killall
-    PS_C="ps -C"
+    if [ -f /etc/centos-release ]; then
+        KILLALL=pkill
+        PS_C="pgrep -l"
+    else
+        KILLALL=killall
+        PS_C="ps -C"
+    fi
 fi
 
 if [ -n "$BUILD_DYNAMIC_MODULE" ]; then


### PR DESCRIPTION
I changed test.sh to use pkill instead of killall for CentOS. killall isn't installed by default.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
