### PR TITLE
Fix portability for sh script

### DIFF
--- a/update-devkit-subtree
+++ b/update-devkit-subtree
@@ -10,7 +10,7 @@ if [ $? -ne 0 ]; then
   echo "Missing remote repository ${REMOTE_REPO_NAME}"
   echo -n "Do you want to add (y/n)? "
   read answer
-  if [ X$answer == "Xy" -o X$answer == "XY" ]; then
+  if [ X$answer = "Xy" -o X$answer = "XY" ]; then
     git remote add ${REMOTE_REPO_NAME} ${REMOTE_REPO_URL}
     echo "Added ${REMOTE_REPO_URL} as ${REMOTE_REPO_NAME}."
   else

--- a/update-mruby-subtree
+++ b/update-mruby-subtree
@@ -10,7 +10,7 @@ if [ $? -ne 0 ]; then
   echo "Missing remote repository ${REMOTE_REPO_NAME}"
   echo -n "Do you want to add (y/n)? "
   read answer
-  if [ X$answer == "Xy" -o X$answer == "XY" ]; then
+  if [ X$answer = "Xy" -o X$answer = "XY" ]; then
     git remote add ${REMOTE_REPO_NAME} ${REMOTE_REPO_URL}
     echo "Added ${REMOTE_REPO_URL} as ${REMOTE_REPO_NAME}."
   else


### PR DESCRIPTION
"==" operator for test(1) command should not be used for POSIX conformance.
It is a extension feature of bash and other some shell.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
