### PR TITLE
Support build with openssl-1.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,12 @@ env:
     NGINX_SRC_PATCH=2
 
 before_script:
-  - curl -sfL https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz -o openssl-1.0.2.tar.gz
-  - tar -xzf openssl-1.0.2.tar.gz
-  - rm openssl-1.0.2.tar.gz
-  - cd openssl-1.0.2*
-  - ./config --prefix=/usr/local --shared zlib -fPIC enable-tlsext >> /dev/null 2>&1
+  - openssl_version=1.1.1
+  - curl -sfL https://www.openssl.org/source/openssl-${openssl_version}-latest.tar.gz -o openssl-${openssl_version}.tar.gz
+  - tar -xzf openssl-${openssl_version}.tar.gz
+  - rm openssl-${openssl_version}.tar.gz
+  - cd openssl-${openssl_version}*
+  - ./config --prefix=/usr/local --shared zlib -fPIC >> /dev/null 2>&1
   - make >> /dev/null 2>&1
   - sudo make install >> /dev/null 2>&1
   - sudo ldconfig /usr/local/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: cpp
 compiler:
   - gcc
 before_install:
+  - echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+  - echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update
 install:
   - sudo apt-get -qq install rake bison git gperf zlib1g-dev g++-4.9 libstdc++-4.9-dev
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9" LD="gcc-4.9"; fi
   - $CXX -v
 env:
   - NGINX_SRC_MAJOR=1

--- a/Makefile.in
+++ b/Makefile.in
@@ -134,7 +134,11 @@ openssl: .openssl_build_done
 .openssl_configure_done:
 	(cd $(NGX_OPENSSL_SRC) \
 	&& if [ -f Makefile ]; then $(MAKE) clean; fi \
-	&& ./config --prefix=$(NGX_OPENSSL_INSTALL_DIR) --shared zlib -fPIC enable-tlsext $(NGX_OPENSSL_OPT) \
+	&& OPENSSL_VERSION=`grep '^VERSION' Makefile | head -1 | sed 's/VERSION=//'` \
+	&& OPENSSL_MAJOR_VERSION=`echo ${OPENSSL_VERSION} | awk -F '.' '{print $1}'` \
+	&& OPENSSL_MINOR_VERSION=`echo ${OPENSSL_VERSION} | awk -F '.' '{print $2}'` \
+	&& if [ ${OPENSSL_MAJOR_VERSION} -le 1 && ${OPENSSL_MINOR_VERSION} -eq 0 ]; then ENABLE_TLSEXT='enable-tlsext'; fi \
+	&& ./config --prefix=$(NGX_OPENSSL_INSTALL_DIR) --shared zlib -fPIC ${ENABLE_TLSEXT} $(NGX_OPENSSL_OPT) \
 	&& $(MAKE) depend) \
 	&& cp /dev/null .openssl_configure_done
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
   config.vm.provision "shell", :path => "misc/provision.sh", :privileged => false
 end

--- a/misc/Dockerfile.travis_emulate
+++ b/misc/Dockerfile.travis_emulate
@@ -19,11 +19,12 @@ RUN apt-get install -y \
 ENV CXX "g++-4.9"
 ENV CC "gcc-4.9"
 
-RUN curl -L https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz -o openssl-1.0.2.tar.gz && \
-  tar -xzf openssl-1.0.2.tar.gz && \
-  rm openssl-1.0.2.tar.gz && \
-  cd openssl-1.0.2* && \
-  ./config --prefix=/usr/local --shared zlib -fPIC enable-tlsext && \
+RUN openssl_version=1.1.1 && \
+  curl -sfL https://www.openssl.org/source/openssl-${openssl_version}-latest.tar.gz -o openssl-${openssl_version}.tar.gz && \
+  tar -xzf openssl-${openssl_version}.tar.gz && \
+  rm openssl-${openssl_version}.tar.gz && \
+  cd openssl-${openssl_version}* && \
+  ./config --prefix=/usr/local --shared zlib -fPIC >> /dev/null 2>&1 && \
   make && \
   sudo make install && \
   sudo ldconfig /usr/local/lib

--- a/misc/Dockerfile.travis_emulate
+++ b/misc/Dockerfile.travis_emulate
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:bionic
 ## emulates Travis.ci environment
 # Usage:
 #   build:
@@ -8,16 +8,19 @@ FROM ubuntu:14.04
 #       or,
 #     docker run -it -v `pwd`:/ngx_mruby ngx_mruby:branch_name
 
+RUN echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list && \
+    echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y bash-completion apt-file software-properties-common && apt-file update
 RUN add-apt-repository --yes ppa:ubuntu-toolchain-r/test && apt-get update
 RUN apt-get install -y \
   build-essential wget libpcre3-dev psmisc \
   rake bison git gperf zlib1g-dev g++-4.9 libstdc++-4.9-dev \
-  vim tmux
+  vim tmux curl
 
 ENV CXX "g++-4.9"
 ENV CC "gcc-4.9"
+ENV LD "gcc-4.9"
 
 RUN openssl_version=1.1.1 && \
   curl -sfL https://www.openssl.org/source/openssl-${openssl_version}-latest.tar.gz -o openssl-${openssl_version}.tar.gz && \
@@ -26,8 +29,8 @@ RUN openssl_version=1.1.1 && \
   cd openssl-${openssl_version}* && \
   ./config --prefix=/usr/local --shared zlib -fPIC >> /dev/null 2>&1 && \
   make && \
-  sudo make install && \
-  sudo ldconfig /usr/local/lib
+  make install && \
+  ldconfig /usr/local/lib
 
 ## Add or -v `pwd`:/ngx_mruby
 ADD . /ngx_mruby

--- a/misc/provision.sh
+++ b/misc/provision.sh
@@ -23,9 +23,9 @@ curl -sfL https://www.openssl.org/source/openssl-${openssl_version}-latest.tar.g
 tar -xzf openssl-${openssl_version}.tar.gz
 rm openssl-${openssl_version}.tar.gz
 cd openssl-${openssl_version}*
-./config --prefix=/usr/local --shared zlib -fPIC >> /dev/null 2>&1
-make >> /dev/null 2>&1
-sudo make install >> /dev/null 2>&1
+./config --prefix=/usr/local --shared zlib -fPIC
+make
+sudo make install
 sudo ldconfig /usr/local/lib
 cd -
 openssl version

--- a/misc/provision.sh
+++ b/misc/provision.sh
@@ -8,6 +8,7 @@ export LD="gcc-4.9"
 
 grep "^deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" /etc/apt/sources.list || echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" | sudo tee -a /etc/apt/sources.list
 grep "^deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" /etc/apt/sources.list || echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" | sudo tee -a /etc/apt/sources.list
+echo "libssl1.1 libraries/restart-without-asking boolean true" | sudo debconf-set-selections
 
 sudo apt-get update
 sudo apt-get -y install build-essential rake bison git gperf automake m4 \

--- a/misc/provision.sh
+++ b/misc/provision.sh
@@ -1,9 +1,18 @@
 #/bin/sh
 
+echo '
+export CXX="g++-4.9"
+export CC="gcc-4.9"
+export LD="gcc-4.9"
+' | sudo tee /etc/profile.d/env.sh
+
+grep "^deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" /etc/apt/sources.list || echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" | sudo tee -a /etc/apt/sources.list
+grep "^deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" /etc/apt/sources.list || echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" | sudo tee -a /etc/apt/sources.list
+
 sudo apt-get update
 sudo apt-get -y install build-essential rake bison git gperf automake m4 \
                 autoconf libtool cmake pkg-config libcunit1-dev ragel \
-                libpcre3-dev clang-format-6.0
+                libpcre3-dev clang-format-6.0 g++-4.9 libstdc++-4.9-dev
 sudo apt-get -y remove nano
 
 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 1000

--- a/misc/provision.sh
+++ b/misc/provision.sh
@@ -18,4 +18,16 @@ sudo apt-get -y remove nano
 
 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 1000
 
+openssl_version=1.1.1
+curl -sfL https://www.openssl.org/source/openssl-${openssl_version}-latest.tar.gz -o openssl-${openssl_version}.tar.gz
+tar -xzf openssl-${openssl_version}.tar.gz
+rm openssl-${openssl_version}.tar.gz
+cd openssl-${openssl_version}*
+./config --prefix=/usr/local --shared zlib -fPIC >> /dev/null 2>&1
+make >> /dev/null 2>&1
+sudo make install >> /dev/null 2>&1
+sudo ldconfig /usr/local/lib
+cd -
+openssl version
+
 git clone https://github.com/matsumotory/ngx_mruby


### PR DESCRIPTION
This PR will be able to build the ngx_mruby with openssl-1.1.x.

- Support build with openssl-1.1.x (not supported build opt `enable-tlsext` in openssl-1.1 later)
- Some fixes to CI environment with built-in openssl
  - Upgrade OS to ubuntu:bionic to use libssl-1.1
  - Add environment variable `LD`, Required here: https://github.com/mruby/mruby/blob/b7af9c47b3f6ec656f7e2d7ee4c1d11cda667748/mrbgems/mruby-bin-mrbc/mrbgem.rake#L12
  - Same modification to `Dockerfile.travis_emulate`

CI using openssl-1.0.x is gone.
I thought about doing both 1.0 and 1.1, but I thought it would be complicated.

Instead,
I performed a test overwriting this fix with 1.0.2. passed it.
https://github.com/takumakume/ngx_mruby/pull/1


## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
