### PR TITLE
Fix Nginx::Stream::Async race condition

### DIFF
--- a/src/stream/ngx_stream_mruby_async.c
+++ b/src/stream/ngx_stream_mruby_async.c
@@ -16,27 +16,23 @@
 typedef struct {
   mrb_state *mrb;
   mrb_value *fiber;
-  ngx_stream_mruby_internal_ctx_t *ictx;
+  ngx_stream_session_t *s;
 } ngx_stream_mrb_reentrant_t;
 
-static mrb_value ngx_stream_mrb_run_fiber(ngx_stream_mruby_internal_ctx_t *ictx, mrb_state *mrb, mrb_value *fiber_proc,
-                                          mrb_value *result)
+static mrb_value ngx_stream_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber_proc, mrb_value *result)
 {
   mrb_value resume_result = mrb_nil_value();
   mrb_value aliving = mrb_false_value();
   mrb_value handler_result = mrb_nil_value();
   ngx_stream_mruby_ctx_t *ctx;
 
-  ctx = ngx_stream_mrb_get_module_ctx(mrb, ictx->s);
+  ngx_stream_session_t *s = ngx_mrb_get_session();
+  ctx = ngx_stream_mrb_get_module_ctx(mrb, s);
   ctx->fiber_proc = fiber_proc;
-
-  mrb->ud = ictx;
-  // Nginx::Stream::Async.sleep to neeed session
-  ngx_mrb_push_session(ictx->s);
 
   resume_result = mrb_funcall(mrb, *fiber_proc, "call", 0, NULL);
   if (mrb->exc) {
-    ngx_log_error(NGX_LOG_NOTICE, ictx->s->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber",
+    ngx_log_error(NGX_LOG_NOTICE, s->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber",
                   MODULE_NAME, __func__, __LINE__);
     return mrb_false_value();
   }
@@ -57,36 +53,38 @@ static mrb_value ngx_stream_mrb_run_fiber(ngx_stream_mruby_internal_ctx_t *ictx,
   return aliving;
 }
 
-mrb_value ngx_stream_mrb_start_fiber(ngx_stream_mruby_internal_ctx_t *ictx, mrb_state *mrb, struct RProc *rproc,
-                                     mrb_value *result)
+mrb_value ngx_stream_mrb_start_fiber(ngx_stream_session_t *s, mrb_state *mrb, struct RProc *rproc, mrb_value *result)
 {
   struct RProc *handler_proc;
   mrb_value *fiber_proc;
   ngx_stream_mruby_ctx_t *ctx;
 
-  ctx = ngx_stream_mrb_get_module_ctx(mrb, ictx->s);
+  ctx = ngx_stream_mrb_get_module_ctx(mrb, s);
   ctx->async_handler_result = result;
 
   handler_proc = mrb_closure_new(mrb, rproc->body.irep);
-  fiber_proc = (mrb_value *)ngx_palloc(ictx->s->connection->pool, sizeof(mrb_value));
+  fiber_proc = (mrb_value *)ngx_palloc(s->connection->pool, sizeof(mrb_value));
   *fiber_proc =
       mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_ngx_mrb_prepare_fiber", 1, mrb_obj_value(handler_proc));
   if (mrb->exc) {
-    ngx_log_error(NGX_LOG_NOTICE, ictx->s->connection->log, 0,
+    ngx_log_error(NGX_LOG_NOTICE, s->connection->log, 0,
                   "%s NOTICE %s:%d: preparing fiber got the raise, leave the fiber", MODULE_NAME, __func__, __LINE__);
     return mrb_false_value();
   }
 
-  return ngx_stream_mrb_run_fiber(ictx, mrb, fiber_proc, result);
+  return ngx_stream_mrb_run_fiber(mrb, fiber_proc, result);
 }
 
 static ngx_int_t ngx_stream_mrb_post_fiber(ngx_stream_mrb_reentrant_t *re, ngx_stream_mruby_ctx_t *ctx)
 {
   int ai;
   ai = mrb_gc_arena_save(re->mrb);
+  ngx_stream_mruby_internal_ctx_t *ictx = re->mrb->ud;
 
   if (re->fiber != NULL) {
-    if (mrb_test(ngx_stream_mrb_run_fiber(re->ictx, re->mrb, re->fiber, ctx->async_handler_result))) {
+    ngx_mrb_push_session(re->s);
+
+    if (mrb_test(ngx_stream_mrb_run_fiber(re->mrb, re->fiber, ctx->async_handler_result))) {
       mrb_gc_arena_restore(re->mrb, ai);
       return NGX_DONE;
     } else {
@@ -95,23 +93,23 @@ static ngx_int_t ngx_stream_mrb_post_fiber(ngx_stream_mrb_reentrant_t *re, ngx_s
     }
 
     if (re->mrb->exc) {
-      ngx_stream_mruby_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->ictx->s);
+      ngx_stream_mruby_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->s);
       return NGX_ABORT;
     }
 
   } else {
-    ngx_log_error(NGX_LOG_NOTICE, re->ictx->s->connection->log, 0, "%s NOTICE %s:%d: unexpected error, fiber missing",
+    ngx_log_error(NGX_LOG_NOTICE, re->s->connection->log, 0, "%s NOTICE %s:%d: unexpected error, fiber missing",
                   MODULE_NAME, __func__, __LINE__);
     return NGX_ABORT;
   }
 
   mrb_gc_arena_restore(re->mrb, ai);
 
-  if (re->ictx->stream_status == NGX_DECLINED) {
-    re->ictx->s->phase_handler++;
-    ngx_stream_core_run_phases(re->ictx->s);
+  if (ictx->stream_status == NGX_DECLINED) {
+    re->s->phase_handler++;
+    ngx_stream_core_run_phases(re->s);
   }
-  return re->ictx->stream_status;
+  return ictx->stream_status;
 }
 
 static void ngx_stream_mrb_timer_handler(ngx_event_t *ev)
@@ -120,7 +118,7 @@ static void ngx_stream_mrb_timer_handler(ngx_event_t *ev)
   ngx_stream_mruby_ctx_t *ctx;
 
   re = ev->data;
-  ctx = ngx_stream_mrb_get_module_ctx(NULL, re->ictx->s);
+  ctx = ngx_stream_mrb_get_module_ctx(NULL, re->s);
 
   ngx_stream_mrb_post_fiber(re, ctx);
 }
@@ -160,9 +158,9 @@ static mrb_value ngx_stream_mrb_async_sleep(mrb_state *mrb, mrb_value self)
   p = ngx_palloc(s->connection->pool, sizeof(ngx_event_t) + sizeof(ngx_stream_mrb_reentrant_t));
   re = (ngx_stream_mrb_reentrant_t *)(p + sizeof(ngx_event_t));
   re->mrb = mrb;
-  re->ictx = mrb->ud;
+  re->s = s;
 
-  ctx = ngx_stream_mrb_get_module_ctx(mrb, re->ictx->s);
+  ctx = ngx_stream_mrb_get_module_ctx(mrb, s);
   re->fiber = ctx->fiber_proc;
 
   // keeps the object from GC when can resume the fiber

--- a/src/stream/ngx_stream_mruby_async.h
+++ b/src/stream/ngx_stream_mruby_async.h
@@ -9,10 +9,11 @@
 
 #include <ngx_config.h>
 #include <ngx_stream.h>
-
 #include <mruby.h>
+#include "ngx_stream_mruby_module.h"
 
-mrb_value ngx_stream_mrb_start_fiber(ngx_stream_session_t *s, mrb_state *mrb, struct RProc *proc, mrb_value *result);
+mrb_value ngx_stream_mrb_start_fiber(ngx_stream_mruby_internal_ctx_t *ictx, mrb_state *mrb, struct RProc *proc,
+                                     mrb_value *result);
 void ngx_stream_mrb_async_class_init(mrb_state *mrb, struct RClass *class);
 
 #endif // NGX_STREAM_MRUBY_ASYNC_H

--- a/src/stream/ngx_stream_mruby_async.h
+++ b/src/stream/ngx_stream_mruby_async.h
@@ -9,11 +9,10 @@
 
 #include <ngx_config.h>
 #include <ngx_stream.h>
-#include <mruby.h>
-#include "ngx_stream_mruby_module.h"
 
-mrb_value ngx_stream_mrb_start_fiber(ngx_stream_mruby_internal_ctx_t *ictx, mrb_state *mrb, struct RProc *proc,
-                                     mrb_value *result);
+#include <mruby.h>
+
+mrb_value ngx_stream_mrb_start_fiber(ngx_stream_session_t *s, mrb_state *mrb, struct RProc *proc, mrb_value *result);
 void ngx_stream_mrb_async_class_init(mrb_state *mrb, struct RClass *class);
 
 #endif // NGX_STREAM_MRUBY_ASYNC_H

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -704,15 +704,16 @@ static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s)
 
   mrb = ngx_stream_mrb_state(s);
   ai = mrb_gc_arena_save(mrb);
-
   ictx = mrb->ud;
+
   ictx->s = s;
   ictx->stream_status = NGX_DECLINED;
 
   mrb_value *mrb_result = (mrb_value *)ngx_palloc(s->connection->pool, sizeof(mrb_value));
   *mrb_result = mrb_nil_value();
 
-  if (mrb_test(ngx_stream_mrb_start_fiber(ictx, mrb, mscf->code->proc, mrb_result))) {
+  ngx_mrb_push_session(s);
+  if (mrb_test(ngx_stream_mrb_start_fiber(s, mrb, mscf->code->proc, mrb_result))) {
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME,
                   __func__, __LINE__);
 

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -678,18 +678,6 @@ static ngx_int_t ngx_stream_mrb_run_conf(ngx_conf_t *cf, mrb_state *mrb, ngx_mrb
 }
 */
 
-ngx_stream_session_t *ngx_mruby_session = NULL;
-ngx_int_t ngx_mrb_push_session(ngx_stream_session_t *s)
-{
-  ngx_mruby_session = s;
-  return NGX_OK;
-}
-
-ngx_stream_session_t *ngx_mrb_get_session(void)
-{
-  return ngx_mruby_session;
-}
-
 static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s)
 {
   ngx_stream_mruby_srv_conf_t *mscf;
@@ -712,7 +700,6 @@ static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s)
   mrb_value *mrb_result = (mrb_value *)ngx_palloc(s->connection->pool, sizeof(mrb_value));
   *mrb_result = mrb_nil_value();
 
-  ngx_mrb_push_session(s);
   if (mrb_test(ngx_stream_mrb_start_fiber(s, mrb, mscf->code->proc, mrb_result))) {
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME,
                   __func__, __LINE__);

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -704,8 +704,8 @@ static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s)
 
   mrb = ngx_stream_mrb_state(s);
   ai = mrb_gc_arena_save(mrb);
-  ictx = mrb->ud;
 
+  ictx = mrb->ud;
   ictx->s = s;
   ictx->stream_status = NGX_DECLINED;
 
@@ -713,7 +713,7 @@ static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s)
   *mrb_result = mrb_nil_value();
 
   ngx_mrb_push_session(s);
-  if (mrb_test(ngx_stream_mrb_start_fiber(s, mrb, mscf->code->proc, mrb_result))) {
+  if (mrb_test(ngx_stream_mrb_start_fiber(ictx, mrb, mscf->code->proc, mrb_result))) {
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME,
                   __func__, __LINE__);
 

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -712,7 +712,6 @@ static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s)
   mrb_value *mrb_result = (mrb_value *)ngx_palloc(s->connection->pool, sizeof(mrb_value));
   *mrb_result = mrb_nil_value();
 
-  ngx_mrb_push_session(s);
   if (mrb_test(ngx_stream_mrb_start_fiber(ictx, mrb, mscf->code->proc, mrb_result))) {
     ngx_log_error(NGX_LOG_INFO, s->connection->log, 0, "%s INFO %s:%d: already can resume this fiber", MODULE_NAME,
                   __func__, __LINE__);

--- a/src/stream/ngx_stream_mruby_module.h
+++ b/src/stream/ngx_stream_mruby_module.h
@@ -55,7 +55,5 @@ typedef struct {
 
 } ngx_stream_mruby_srv_conf_t;
 
-ngx_int_t ngx_mrb_push_session(ngx_stream_session_t *s);
-ngx_stream_session_t *ngx_mrb_get_session(void);
 void ngx_stream_mruby_raise_error(mrb_state *mrb, mrb_value obj, ngx_stream_session_t *s);
 #endif // NGX_STREAM_MRUBY_MODULE_H

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -93,7 +93,7 @@ stream {
         after = Nginx::Stream::Connection.remote_port
 
         Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "before port: #{before} after port: #{after}"
-        Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT if before == after
+        Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT if before != after
       ';
       proxy_pass static_server0;
   }

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -88,8 +88,12 @@ stream {
       listen 127.0.0.1:12352;
       mruby_stream_code '
         c = Nginx::Stream::Connection.new "dynamic_server1"
+        before = Nginx::Stream::Connection.remote_port
         Nginx::Stream::Async.sleep 3000
-        c.upstream_server = "127.0.0.1:58080"
+        after = Nginx::Stream::Connection.remote_port
+
+        Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "before port: #{before} after port: #{after}"
+        Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT if before == after
       ';
       proxy_pass static_server0;
   }

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -634,7 +634,8 @@ if nginx_features.is_stream_supported?
   end
 
   t.assert('ngx_mruby - Nginx::Stream::Async.sleep', '127.0.0.1:12352 to 127.0.0.1:58080') do
-    res = HttpRequest.new.get('http://127.0.0.1:12352' + '/mruby')
+    `sleep 1 && curl -s -k http://127.0.0.1:12352/mruby -m1 \&`
+    res = HttpRequest.new.get('http://127.0.0.1:12352/mruby')
     t.assert_equal 'Hello ngx_mruby world!', res["body"]
   end
 end


### PR DESCRIPTION
Hi Mats!!!
Have you eaten dinner??

Nginx::Stream module is using `mrb->ud`.
it is a possibility of becoming a race condition when call Nginx::Stream::Async.sleep.

In this patch, added mrb-> ud consistency before and after run fiber.
Thanks!


## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
