### PR TITLE
Fix link in document

### DIFF
--- a/docs/class_and_method/README.md
+++ b/docs/class_and_method/README.md
@@ -676,7 +676,7 @@ v.exist? "foo" #=> false
 ### Nginx::Request#headers_in -> headers_in
 
 Returns a Headers_in instance of the request.
-See [Nginx::Headers_in Class](#nginxvar-class) for more details.
+See [Nginx::Headers_in Class](#nginxheaders_in-class) for more details.
 
 ```ruby
 r = Nginx::Request.new


### PR DESCRIPTION
Fix a wrong link in document.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
