### PR TITLE
Fixed multiple definition errors with -fno-common

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,11 +16,11 @@ set -e
 # OS specific configuration
 if [ `uname -s` = "NetBSD" ]; then
     NPROCESSORS_ONLN="NPROCESSORS_ONLN"
-    NGINX_DEFAULT_OPT='--with-http_stub_status_module --with-stream --without-stream_access_module --with-ld-opt=-L/usr/pkg/lib\ -Wl,-R/usr/pkg/lib'
+    NGINX_DEFAULT_OPT='--with-http_stub_status_module --with-stream --without-stream_access_module --with-cc-opt=-fno-common --with-ld-opt=-L/usr/pkg/lib\ -Wl,-R/usr/pkg/lib'
     MAKE=gmake
 else
     NPROCESSORS_ONLN="_NPROCESSORS_ONLN"
-    NGINX_DEFAULT_OPT='--with-http_stub_status_module --with-stream --without-stream_access_module'
+    NGINX_DEFAULT_OPT='--with-http_stub_status_module --with-stream --without-stream_access_module --with-cc-opt=-fno-common'
     MAKE=make
 fi
 

--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -13,8 +13,6 @@
 #include "mruby/string.h"
 #include "mruby/variable.h"
 
-ngx_module_t ngx_http_mruby_module;
-
 #if (NGX_DEBUG)
 static void ngx_mrb_log_backtrace(mrb_state *mrb, mrb_value obj, ngx_log_t *log)
 {

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -27,6 +27,9 @@
     (code)->ctx = NULL;                                                                                                \
   }
 
+ngx_http_output_header_filter_pt ngx_http_next_header_filter;
+ngx_http_output_body_filter_pt ngx_http_next_body_filter;
+
 // set conf
 static void *ngx_http_mruby_create_srv_conf(ngx_conf_t *cf);
 static char *ngx_http_mruby_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child);

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -103,7 +103,7 @@ typedef struct ngx_http_mruby_loc_conf_t {
   ngx_http_output_body_filter_pt body_filter_handler;
 } ngx_http_mruby_loc_conf_t;
 
-ngx_http_output_header_filter_pt ngx_http_next_header_filter;
-ngx_http_output_body_filter_pt ngx_http_next_body_filter;
+extern ngx_http_output_header_filter_pt ngx_http_next_header_filter;
+extern ngx_http_output_body_filter_pt ngx_http_next_body_filter;
 
 #endif // NGX_HTTP_MRUBY_MODULE_H

--- a/src/stream/ngx_stream_mruby_core.c
+++ b/src/stream/ngx_stream_mruby_core.c
@@ -10,7 +10,7 @@
 
 #include <mruby/hash.h>
 #include <mruby/string.h>
-ngx_module_t ngx_stream_mruby_module;
+
 static mrb_value ngx_stream_mrb_errlogger(mrb_state *mrb, mrb_value self)
 {
   mrb_value msg;

--- a/src/stream/ngx_stream_mruby_core.h
+++ b/src/stream/ngx_stream_mruby_core.h
@@ -23,4 +23,6 @@ typedef struct ngx_stream_mruby_ctx_t {
 
 ngx_stream_mruby_ctx_t *ngx_stream_mrb_get_module_ctx(mrb_state *mrb, ngx_stream_session_t *s);
 
+extern ngx_module_t ngx_stream_mruby_module;
+
 #endif // NGX_STREAM_MRUBY_CORE_H

--- a/test.sh
+++ b/test.sh
@@ -12,13 +12,13 @@ set -e
 # OS specific configuration
 if [ `uname -s` = "NetBSD" ]; then
     NPROCESSORS_ONLN="NPROCESSORS_ONLN"
-    NGINX_DEFAULT_OPT='--with-debug --with-http_stub_status_module --with-http_ssl_module --with-ld-opt=-L/usr/pkg/lib\ -Wl,-R/usr/pkg/lib --with-cc-opt=-g\ -O0'
+    NGINX_DEFAULT_OPT='--with-debug --with-http_stub_status_module --with-http_ssl_module --with-ld-opt=-L/usr/pkg/lib\ -Wl,-R/usr/pkg/lib --with-cc-opt=-g\ -O0\ -fno-common'
     MAKE=gmake
     KILLALL=pkill
     PS_C="pgrep -l"
 else
     NPROCESSORS_ONLN="_NPROCESSORS_ONLN"
-    NGINX_DEFAULT_OPT='--with-debug --with-http_stub_status_module --with-http_ssl_module --with-cc-opt=-g\ -O0'
+    NGINX_DEFAULT_OPT='--with-debug --with-http_stub_status_module --with-http_ssl_module --with-cc-opt=-g\ -O0\ -fno-common'
     MAKE=make
     if [ -f /etc/centos-release ]; then
         KILLALL=pkill


### PR DESCRIPTION
Fixed multiple definition errors with -fno-common. Fixed #451 

## Pull-Request Check List

- [x] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
