### PR TITLE
Fix #448 and minor build system issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ build_dynamic/
 autom4te.cache/
 .openssl_build_done
 .openssl_configure_done
+.mruby_version
 .vagrant/

--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ build_mruby: $(MRUBY_BUILD_DEPEND_TARGETS)
 
 clean_mruby:
 	rm -f .mruby_version	
-	cd $(MRUBY_ROOT) && $(RAKE) deep_clean && rm -rf build
+	cd $(MRUBY_ROOT) && $(RAKE) MRUBY_CONFIG=$(NGX_MRUBY_ROOT)/build_config.rb deep_clean && rm -rf build
 
 $(MRUBY_MAK_FILE): build_mruby
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -61,15 +61,26 @@ clean:
 	-rm -rf mrbgems_config mrbgems_config_dynamic
 
 clobber: clean_mruby clean
-	-rm -rf tmp autom4te.cache config config.status config.log $(BUILD_DIR) .openssl_build_done .openssl_configure_done
+	-rm -rf tmp autom4te.cache config config.status config.log $(BUILD_DIR) .openssl_build_done .openssl_configure_done .mruby_version
 
 #
 # mruby
 #
 build_mruby: $(MRUBY_BUILD_DEPEND_TARGETS)
+	@if [ -f .mruby_version ]; then \
+		built_version=`cat .mruby_version`; \
+		current_version=`git log -1 --format="%H" mruby`; \
+		if [ $$built_version != $$current_version ]; then \
+			echo $$current_version > .mruby_version; \
+			cd $(MRUBY_ROOT) && rm -rf build; \
+		fi; \
+	else \
+		git log -1 --format="%H" mruby > .mruby_version; \
+	fi
 	cd $(MRUBY_ROOT) && $(RAKE) MRUBY_CONFIG=$(NGX_MRUBY_ROOT)/build_config.rb NGX_MRUBY_CFLAGS="$(NGX_MRUBY_CFLAGS)"
 
 clean_mruby:
+	rm -f .mruby_version	
 	cd $(MRUBY_ROOT) && $(RAKE) deep_clean && rm -rf build
 
 $(MRUBY_MAK_FILE): build_mruby

--- a/build.sh
+++ b/build.sh
@@ -87,13 +87,6 @@ else
     OPENSSL_BUILD_OPT=''
 fi
 
-# FIXME: not sure if we really need this. even if we do, it should be moved to mruby/Rakefile
-if [ -d "./mruby/${BUILD_DIR}" ]; then
-    echo "mruby Cleaning ..."
-    (cd mruby && rake clean MRUBY_CONFIG=../build_config.rb)
-    echo "mruby Cleaning ... Done"
-fi
-
 echo "ngx_mruby configure ..."
 ./configure ${CONFIG_OPT} --with-ngx-src-root=${NGINX_SRC} --with-ngx-config-opt="${NGINX_CONFIG_OPT}" ${OPENSSL_BUILD_OPT} $@
 echo "ngx_mruby configure ... Done"


### PR DESCRIPTION
* Remove mruby/build/* if mruby source is newer. Fix #448
* Don't remove mruby/build/* in build.sh. It is done by Makefile if necessary.
* Invoke rake with our own build_config.rb.

## Pull-Request Check List

- [x] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
