### PR TITLE
Add -I options only to CORE_LIBS to fix #400.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -104,7 +104,7 @@ mrbgems_config_dynamic: $(MRUBY_MAK_FILE)
 
 generate_gems_config:
 	@echo CORE_LIBS=\"\$$CORE_LIBS $(LDFLAGS) $(LIBS)\" > ./mrbgems_config
-	@echo CORE_INCS=\"\$$CORE_INCS $(CFLAGS)\" >> ./mrbgems_config
+	@echo CORE_INCS=\"\$$CORE_INCS `echo $(CFLAGS) | sed -e 's/-[^I][^ ]*//g'`\" >> ./mrbgems_config
 	@echo LINK_DEPS=\"\$$LINK_DEPS $(MRUBY_LIBMRUBY_PATH)\" >> ./mrbgems_config
 
 generate_gems_config_dynamic:


### PR DESCRIPTION
Add -I options only to CORE_LIBS to avoid generating strange compiler options like "-I -g -I -std=gnu99 -I -O3 -I -Wall".

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
