### PR TITLE
Refactoing openssl tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,3 +93,4 @@ script:
 
 after_failure:
   - if [ -e build/nginx/logs/error.log ]; then cat build/nginx/logs/error.log ; else cat build_dynamic/nginx/logs/error.log; fi
+  - if [ -e build/nginx/logs/stderr.log ]; then cat build/nginx/logs/stderr.log ; else cat build_dynamic/nginx/logs/stderr.log; fi

--- a/test.sh
+++ b/test.sh
@@ -110,16 +110,14 @@ fi
 cp -pr test/html/* ${NGINX_INSTALL_DIR}/html/.
 sed -e "s|__NGXDOCROOT__|${NGINX_INSTALL_DIR}/html/|g" test/html/set_ssl_cert_and_key.rb > ${NGINX_INSTALL_DIR}/html/set_ssl_cert_and_key.rb
 
-if [ -e ${NGINX_INSTALL_DIR}/logs/error.log ]; then
-    touch ${NGINX_INSTALL_DIR}/logs/error.log.bak 
-    cat ${NGINX_INSTALL_DIR}/logs/error.log >> ${NGINX_INSTALL_DIR}/logs/error.log.bak
-    cp /dev/null ${NGINX_INSTALL_DIR}/logs/error.log
-fi
-if [ -e ${NGINX_INSTALL_DIR}/logs/access.log ]; then
-    touch ${NGINX_INSTALL_DIR}/logs/access.log.bak 
-    cat ${NGINX_INSTALL_DIR}/logs/access.log >> ${NGINX_INSTALL_DIR}/logs/access.log.bak
-    cp /dev/null ${NGINX_INSTALL_DIR}/logs/access.log
-fi
+for f in error.log access.log stderr.log
+do
+    if [ -e ${NGINX_INSTALL_DIR}/logs/${f} ]; then
+        touch ${NGINX_INSTALL_DIR}/logs/${f}.bak 
+        cat ${NGINX_INSTALL_DIR}/logs/${f} >> ${NGINX_INSTALL_DIR}/logs/${f}.bak
+        cp /dev/null ${NGINX_INSTALL_DIR}/logs/${f}
+    fi
+done
 
 echo "====================================="
 echo ""
@@ -132,7 +130,7 @@ ${NGINX_INSTALL_DIR}/sbin/nginx &
 echo ""
 echo ""
 sleep 2 # waiting for nginx
-./mruby/build/test/bin/mruby ./test/t/ngx_mruby.rb
+./mruby/build/test/bin/mruby ./test/t/ngx_mruby.rb 2> ${NGINX_INSTALL_DIR}/logs/stderr.log
 $KILLALL nginx
 echo "ngx_mruby testing ... Done"
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -35,7 +35,8 @@ class NginxFeatures
 end
 
 class OpenSSLTestClient
-  def debug?; ENV['DEBUG']; end
+  # On Travis, always debug? returns true to narrow down build issues.
+  def debug?; ENV['DEBUG'] || ENV['TRAVIS'] ; end
   def run(openssl_cmd); @openssl_cmd = openssl_cmd; @request = nil; @to_text = false; self; end
   def with(request); @request = request; self; end
   def to_text; @to_text = true; self; end
@@ -51,9 +52,9 @@ class OpenSSLTestClient
   def run_again; @pipe_cmd.nil? ? now() : pipe(@pipe_cmd); end
   def _run
     if debug?
-      puts "DEBUG: openssl_cmd: #{@openssl_cmd}" 
-      puts "DEBUG: request: #{@request}"
-      puts "DEBUG: to_text: #{@to_text}"
+      STDERR.puts "DEBUG: openssl_cmd: #{@openssl_cmd}" 
+      STDERR.puts "DEBUG: request: #{@request}"
+      STDERR.puts "DEBUG: to_text: #{@to_text}"
     end
     raise "Call run() first." if @openssl_cmd.nil?
     @result_text = ""
@@ -62,13 +63,13 @@ class OpenSSLTestClient
       "#{@openssl_cmd} < /dev/null 2> /dev/null" : 
       "echo #{@request} | #{@openssl_cmd} 2> /dev/null"
     cmd = cmd + " | openssl x509 -text" if @to_text
-    puts "DEBUG: cmd: #{cmd}" if debug?
+    STDERR.puts "DEBUG: cmd: #{cmd}" if debug?
 
     @result_text = `#{cmd}`
     if debug?
-      puts "DEBUG: result_text --- BEGIN ---"
-      puts "#{@result_text}"
-      puts "DEBUG: result_text --- END ---"
+      STDERR.puts "DEBUG: result_text --- BEGIN ---"
+      STDERR.puts "#{@result_text}"
+      STDERR.puts "DEBUG: result_text --- END ---"
     end
     @result_text
   end

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -18,7 +18,7 @@ class NginxFeatures
   def initialize(nginx_version)
     @version_string = nginx_version
     @major, @minor, @patch = @version_string.split(".").map {|v| v.to_i}
-    p "version_string=#{@version_string}, major=#{@major}, minor=#{@minor}, patch=#{@patch}"
+    puts "Using Nginx #{@version_string} (major=#{@major}, minor=#{@minor}, patch=#{@patch})"
   end
   def is_upstream_supported?
     # Nginx::Upstream only works with nginx 1.7 or later. See ngx_http_mruby_module.h
@@ -39,6 +39,7 @@ class OpenSSLTestClient
   def run(openssl_cmd); @openssl_cmd = openssl_cmd; @request = nil; @to_text = false; self; end
   def with(request); @request = request; self; end
   def to_text; @to_text = true; self; end
+  def now; _run(); end
   def pipe(pipe_cmd)
    @pipe_cmd = pipe_cmd
    IO.pipe do |r, w|
@@ -47,7 +48,7 @@ class OpenSSLTestClient
      IO.popen(pipe_cmd, "r", in: r) { |i| i.read }
     end
   end
-  def run_again; pipe(@pipe_cmd); end
+  def run_again; @pipe_cmd.nil? ? now() : pipe(@pipe_cmd); end
   def _run
     if debug?
       puts "DEBUG: openssl_cmd: #{@openssl_cmd}" 
@@ -363,7 +364,6 @@ end
 t.assert('ngx_mruby - rack base', 'location /rack_base_env') do
   res = HttpRequest.new.get base + '/rack_base_env?a=1&b=1', nil, {"Host" => "ngx.example.com:58080", "x-hoge" => "foo"}
   body = JSON.parse res["body"]
-  puts body
 
   t.assert_equal "GET", body["REQUEST_METHOD"]
   t.assert_equal "", body["SCRIPT_NAME"]
@@ -392,7 +392,6 @@ t.assert('ngx_mruby - rack base', 'method POST, location /rack_base_env') do
   req_body = 'Hello'
   res = HttpRequest.new.post base + '/rack_base_env', req_body, {"Content-Type" => "text/plain; charset=us-ascii", "Content-Length" => req_body.size}
   res_body = JSON.parse res["body"]
-  puts res_body
 
   t.assert_equal "POST", res_body["REQUEST_METHOD"]
   t.assert_equal "text/plain; charset=us-ascii", res_body["CONTENT_TYPE"]
@@ -460,7 +459,6 @@ end
 t.assert('ngx_mruby - fix bug issue 155', 'location /fix-bug-issue-155') do
   res = HttpRequest.new.get base + '/fix-bug-issue-155'
   t.assert_equal 200, res.code
-  p res
   t.assert_equal '["abc=123", "foo=bar"]', res["body"]
   t.assert_equal ["abc=123", "foo=bar"], res['set-cookies']
 end
@@ -564,28 +562,46 @@ t.assert('ngx_mruby - ssl certificate changing - reading handler from file with 
   content = File.read(fname).gsub('#{ssl.servername}', 'localhost')
   File.open(fname, 'w') { |f| f.puts content }
 
-  cmd_l = "openssl s_client -servername localhost -connect localhost:58086 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e 's/://' | awk '{print (res = $6 - res)}' | tail -n 1"
-  cmd_h = "openssl s_client -servername hogehoge -connect 127.0.0.1:58086 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not"
-  t.assert_equal "1", `#{cmd_l}`.chomp
-  t.assert_equal "", `#{cmd_h}`.chomp
+  client_l = OpenSSLTestClient.new
+  client_h = OpenSSLTestClient.new
+
+  res_l = client_l
+    .run("openssl s_client -servername localhost -connect localhost:58086")
+    .to_text()
+    .pipe("grep Not | sed -e 's/://' | awk '{print (res = $6 - res)}' | tail -n 1")
+  res_h = client_h
+    .run("openssl s_client -servername hogehoge -connect 127.0.0.1:58086")
+    .to_text()
+    .pipe("grep Not")
+
+  t.assert_equal "1", res_l.chomp
+  t.assert_equal "", res_h.chomp
 
   content = File.read(fname).gsub('localhost', '#{ssl.servername}')
   File.open(fname, 'w') { |f| f.puts content }
 
-  t.assert_equal "1", `#{cmd_l}`.chomp
-  t.assert_equal "", `#{cmd_h}`.chomp
+  t.assert_equal "1", client_l.run_again.chomp
+  t.assert_equal "", client_h.run_again.chomp
 end
 
 t.assert('ngx_mruby - Nginx::SSL.errlogger') do
-  `openssl s_client -servername localhost -connect localhost:58087 < /dev/null 2>/dev/null`
+  OpenSSLTestClient.new
+    .run("openssl s_client -servername localhost -connect localhost:58087").now
   error_log = File.read File.join(ENV['NGINX_INSTALL_DIR'], 'logs/error.log');
   t.assert_true error_log.include? 'Servername is localhost while SSL handshaking'
 end
 
 t.assert('ngx_mruby - get ssl server name') do
-  res = `echo "GET /servername" | openssl s_client -ign_eof -connect localhost:58088 2>/dev/null | sed -n '$s/closed$//p'`
+  res = OpenSSLTestClient.new
+    .run("openssl s_client -ign_eof -connect localhost:58088")
+    .with("GET /servername")
+    .pipe("sed -n '$s/closed$//p'")
   t.assert_equal "servername is empty", res.chomp
-  res = `echo "GET /servername" | openssl s_client -ign_eof -connect localhost:58088 -servername ngx.example.com 2>/dev/null | sed -n '$s/closed$//p'`
+
+  res = OpenSSLTestClient.new
+    .run("openssl s_client -ign_eof -connect localhost:58088 -servername ngx.example.com")
+    .with("GET /servername")
+    .pipe("sed -n '$s/closed$//p'")
   t.assert_equal "ngx.example.com", res.chomp
 end
 


### PR DESCRIPTION
Introduce OpenSSLTestClient for making debug easier.
You can see output of openssl command if you run the test with DEBUG environment variable.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
