### PR TITLE
Fix Nginx::Headers_in[] returns wrong value. Fixed #471.

### DIFF
--- a/src/http/ngx_http_mruby_request.c
+++ b/src/http/ngx_http_mruby_request.c
@@ -156,7 +156,8 @@ static mrb_value ngx_mrb_get_request_header(mrb_state *mrb, ngx_list_t *headers,
       i = 0;
     }
 
-    if (ngx_strncasecmp(header[i].key.data, key, key_len) == 0) {
+    if (header[i].key.len == key_len &&
+      ngx_strncasecmp(header[i].key.data, key, key_len) == 0) {
       mrb_ary_push(mrb, ary, mrb_str_new(mrb, (const char *)header[i].value.data, header[i].value.len));
     }
   }

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -928,6 +928,14 @@ http {
               end
             ';
         }
+
+        location /issue-471 {
+            mruby_content_handler_code '
+              h = Nginx::Headers_in.new
+              Nginx.rputs h["X-Foo"]
+              Nginx.rputs h["X-Foo-Bar"]
+            ';
+        }
     }
 
     server {

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -780,6 +780,11 @@ if nginx_features.is_async_supported?
     res = HttpRequest.new.get base + '/iv_init_worker'
     t.assert_equal 'true', res["body"]
   end
+
+  t.assert('ngx_mruby - BUG: header issue 471', 'location /issue-471') do
+    res = HttpRequest.new.get base + '/issue-471', nil, {"X-Foo" => "foo", "X-Foo-Bar" => "bar"}
+    t.assert_equal 'foobar', res["body"]
+  end
 end
 
 


### PR DESCRIPTION
## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).

The pull request fixes #471.