### PR TITLE
fix document link on ngx_mruby gh_pages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,11 +33,11 @@
 <a id="documents" class="anchor" href="#documents" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Documents</h2>
 
 <ul>
-<li><a href="https://github.com/matsumoto-r/ngx_mruby/wiki/Install">Install</a></li>
-<li><a href="https://github.com/matsumoto-r/ngx_mruby/wiki/Test">Test</a></li>
-<li><a href="https://github.com/matsumoto-r/ngx_mruby/wiki/Directives">Directives</a></li>
-<li><a href="https://github.com/matsumoto-r/ngx_mruby/wiki/Class-and-Method">Class and Method</a></li>
-<li><a href="https://github.com/matsumoto-r/ngx_mruby/wiki/Use-Case">Use Case</a></li>
+<li><a href="https://github.com/matsumotory/ngx_mruby/tree/master/docs/install">Install</a></li>
+<li><a href="https://github.com/matsumotory/ngx_mruby/tree/master/docs/test">Test</a></li>
+<li><a href="https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives">Directives</a></li>
+<li><a href="https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method">Class and Method</a></li>
+<li><a href="https://github.com/matsumotory/ngx_mruby/tree/master/docs/use_case">Use Case</a></li>
 <li><a href="https://github.com/hsbt/nginx-tech-talk">Examples</a></li>
 </ul>
 


### PR DESCRIPTION
fix document link on ngx_mruby gh_pages.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
