### PR TITLE
Fix error when provisioning Vagrant environment

### DIFF
--- a/misc/provision.sh
+++ b/misc/provision.sh
@@ -13,7 +13,8 @@ echo "libssl1.1 libraries/restart-without-asking boolean true" | sudo debconf-se
 sudo apt-get update
 sudo apt-get -y install build-essential rake bison git gperf automake m4 \
                 autoconf libtool cmake pkg-config libcunit1-dev ragel \
-                libpcre3-dev clang-format-6.0 g++-4.9 libstdc++-4.9-dev
+                libpcre3-dev clang-format-6.0 g++-4.9 libstdc++-4.9-dev \
+                zlib1g-dev
 sudo apt-get -y remove nano
 
 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 1000


### PR DESCRIPTION
Fix error when provisioning Vagrant environment.

```
    default: crypto/comp/c_zlib.c:35:11: fatal error: zlib.h: No such file or directory
    default:  # include <zlib.h>
    default:            ^~~~~~~~
    default: compilation terminated.
```

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
