### PR TITLE
There are cases where I explicitly want to return 503.

### DIFF
--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -278,7 +278,14 @@ static ngx_int_t ngx_mrb_async_http_sub_request_done(ngx_http_request_t *sr, voi
                  sr->parent->headers_out.status);
   ctx->sub_response_more = 0;
 
-  return ngx_mrb_post_fiber(re, ctx);
+  rc = ngx_mrb_post_fiber(re, ctx);
+
+  if (rc != NGX_DECLINED && rc != NGX_OK) {
+    ngx_http_finalize_request(re->r, rc);
+    return NGX_DONE;
+  }
+
+  return rc;
 }
 
 static mrb_value ngx_mrb_async_http_sub_request(mrb_state *mrb, mrb_value self)

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -842,6 +842,16 @@ http {
             ';
         }
 
+        location /async_http_sub_request_with_serverfault {
+            mruby_rewrite_handler_code '
+              Nginx.return -> do
+                Nginx::Async::HTTP.sub_request "/sub_req_proxy_pass"
+                Nginx::Async::HTTP.last_response
+                return Nginx::HTTP_SERVICE_UNAVAILABLE
+              end.call
+            ';
+        }
+
         location /sub_req_dst {
             mruby_content_handler_code '
               Nginx.rputs Nginx::Request.new.uri_args.inspect

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -745,6 +745,10 @@ if nginx_features.is_async_supported?
     t.assert_equal 200, res["code"]
     t.assert_equal 'proxy test ok', res["body"]
   end
+  t.assert('ngx_mruby - Nginx::Async::HTTP.new sub request with proxy', 'location /async_http_sub_request_with_serverfalt') do
+    res = HttpRequest.new.get base + '/async_http_sub_request_with_serverfault'
+    t.assert_equal 503, res['code']
+  end
 
   t.assert('ngx_mruby - Nginx::Async::HTTP.new "/dst"', 'location /async_http_sub_request') do
     res = HttpRequest.new.get base + '/async_http_sub_request_with_hash'


### PR DESCRIPTION
Async.subrequestを利用する際に、すぐに503を返したいケースなどがあり、対応できていなかったので、Nginx::DECLINE、Nginx::OK以外のときは即レスポンスを返すようにします。

## Pull-Request Check List

- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
