### PR TITLE
When subrequest is used, set value is not used.

### DIFF
--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -190,6 +190,8 @@ http {
         server_name  localhost;
         root __NGXDOCROOT__;
 
+        mruby_set_code $subrequest_after_backend '"127.0.0.1:58081"';
+
         # test for hello world and cache option
         location /mruby {
             mruby_content_handler build/nginx/html/unified_hello.rb cache;
@@ -850,6 +852,15 @@ http {
                 return Nginx::HTTP_SERVICE_UNAVAILABLE
               end.call
             ';
+        }
+
+        location /async_http_sub_request_with_mruby_set {
+            mruby_rewrite_handler_code '
+              Nginx::Async::HTTP.sub_request "/sub_req_proxy_pass"
+              Nginx::Async::HTTP.last_response
+            ';
+            proxy_pass  http://$subrequest_after_backend;
+
         }
 
         location /sub_req_dst {

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # ngx_mruby test
 #
 
@@ -745,9 +746,16 @@ if nginx_features.is_async_supported?
     t.assert_equal 200, res["code"]
     t.assert_equal 'proxy test ok', res["body"]
   end
+
   t.assert('ngx_mruby - Nginx::Async::HTTP.new sub request with proxy', 'location /async_http_sub_request_with_serverfalt') do
     res = HttpRequest.new.get base + '/async_http_sub_request_with_serverfault'
     t.assert_equal 503, res['code']
+  end
+
+  t.assert('ngx_mruby - Nginx.Async.sub request with proxy(set_code)', 'location /async_http_sub_request_with_mruby_set') do
+    res = HttpRequest.new.get base + '/async_http_sub_request_with_mruby_set'
+    t.assert_equal 'proxy test ok', res['body']
+    t.assert_equal 200, res.code
   end
 
   t.assert('ngx_mruby - Nginx::Async::HTTP.new "/dst"', 'location /async_http_sub_request') do


### PR DESCRIPTION
## Pull-Request Check List
サブリクエストの実行時にも `mruby_set_code` で値を埋め込もうとしてしまっており、ファイバーの実行結果という意図しない値が設定されてしまう不具合があったので修正しました。1コミットめでテストが落ちて、2コミットめで通るようになってます。


- [x] Add patches into `src/`.
- [x] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [x] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
