### PR TITLE
Fix http_mruby_module return statement

### DIFF
--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -1776,16 +1776,17 @@ static ngx_int_t ngx_http_mruby_header_filter(ngx_http_request_t *r)
   cln->handler = ngx_http_mruby_filter_cleanup;
   cln->data = ctx;
 
-  if (mlcf->header_filter_handler != NULL) {
-    rc = mlcf->header_filter_handler(r);
-    if (rc != NGX_OK) {
-      return NGX_ERROR;
-    }
+  if (mlcf->header_filter_handler == NULL) {
+    return NGX_OK;
+  }
+
+  rc = mlcf->header_filter_handler(r);
+  if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
+    return rc;
   }
 
   ctx->body_length = r->headers_out.content_length_n;
-
-  return NGX_OK;
+  return rc;
 }
 
 static ngx_int_t ngx_http_mruby_body_filter(ngx_http_request_t *r, ngx_chain_t *in)


### PR DESCRIPTION
Fix: https://github.com/matsumotory/ngx_mruby/issues/508

In the code for http_mruby_module, header_filter return `NGX_ERROR` when other filters don't return `NGX_OK`.
If filters that return `NGX_AGAIN`, such as HTTP2 module,  it will not be processed correctly.

## Pull-Request Check List

- [x] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
