### PR TITLE
not need to call ngx_http_run_posted_requests

### DIFF
--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -113,8 +113,6 @@ static ngx_int_t ngx_mrb_post_fiber(ngx_mrb_reentrant_t *re, ngx_http_mruby_ctx_
       re->fiber = NULL;
     }
 
-    ngx_http_run_posted_requests(re->r->connection);
-
     if (re->mrb->exc) {
       ngx_mrb_raise_error(re->mrb, mrb_obj_value(re->mrb->exc), re->r);
       rc = NGX_HTTP_INTERNAL_SERVER_ERROR;

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -849,10 +849,31 @@ http {
               Nginx.return -> do
                 Nginx::Async::HTTP.sub_request "/sub_req_proxy_pass"
                 Nginx::Async::HTTP.last_response
+                Nginx::HTTP_SERVICE_UNAVAILABLE
+              end.call
+            ';
+        }
+
+        location /subrequest_redirect_from {
+            rewrite ^.*$ /subrequest_redirect_to last;
+            mruby_rewrite_handler_code '
+              Nginx.return -> do
+                Nginx::Async::HTTP.sub_request "/async_http_sub_request_with_serverfault"
+                Nginx::Async::HTTP.last_response
+                return Nginx::DECLINED
+              end.call
+            ';
+        }
+        location /subrequest_redirect_to {
+            mruby_rewrite_handler_code '
+              Nginx.return -> do
+                Nginx::Async::HTTP.sub_request "/async_http_sub_request_with_serverfault"
+                Nginx::Async::HTTP.last_response
                 return Nginx::HTTP_SERVICE_UNAVAILABLE
               end.call
             ';
         }
+
 
         location /async_http_sub_request_with_mruby_set {
             mruby_rewrite_handler_code '

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -752,6 +752,11 @@ if nginx_features.is_async_supported?
     t.assert_equal 503, res['code']
   end
 
+  t.assert('ngx_mruby - Nginx::Async::HTTP.new sub request with nginx rewrite', 'location /subrequest_redirect_from') do
+    res = HttpRequest.new.get base + '/subrequest_redirect_from'
+    t.assert_equal 503, res['code']
+  end
+
   t.assert('ngx_mruby - Nginx.Async.sub request with proxy(set_code)', 'location /async_http_sub_request_with_mruby_set') do
     res = HttpRequest.new.get base + '/async_http_sub_request_with_mruby_set'
     t.assert_equal 'proxy test ok', res['body']


### PR DESCRIPTION
@matsumotory Please review.
sub requestのあとは明示的に `ngx_http_run_posted_requests` を呼び出して他のイベントをコールしないと行けないと思っていたのだがそんなことはなかったので、呼び出すをやめました。

元々顕在化した事象は、mrubyでrewrite handlerを使いつつ、nginxでもrewriteしているときにfinalizerが多重に呼ばれてセグフォするという問題が起きてそれで気づきました。なお、1.5日かけて、1行消すだけのあれだった・・・。

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
