### PR TITLE
The return value of a subrequest can be retrieved immediately.

### DIFF
--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -115,23 +115,6 @@ ngx_int_t ngx_mrb_finalize_rputs(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ct
   return rc;
 }
 
-static void ngx_http_mrb_read_subrequest_responce(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ctx)
-{
-  ngx_http_mruby_ctx_t *main_ctx;
-  main_ctx = ngx_mrb_http_get_module_ctx(NULL, r->main);
-
-  ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s DEBUG %s:%d: r->main parse subrequest response", MODULE_NAME,
-                __func__, __LINE__);
-
-  if (main_ctx != NULL && ctx->body_length > 0) {
-    main_ctx->sub_response_body = ngx_palloc(r->pool, ctx->body_length);
-    ngx_memcpy(main_ctx->sub_response_body, ctx->body, ctx->body_length);
-    main_ctx->sub_response_body_length = ctx->body_length;
-    main_ctx->sub_response_status = r->headers_out.status;
-    main_ctx->sub_response_headers = r->headers_out;
-  }
-}
-
 ngx_int_t ngx_mrb_finalize_body_filter(ngx_http_request_t *r, ngx_http_mruby_ctx_t *ctx)
 {
   ngx_buf_t *b;
@@ -164,11 +147,6 @@ ngx_int_t ngx_mrb_finalize_body_filter(ngx_http_request_t *r, ngx_http_mruby_ctx
 
   ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s DEBUG %s:%d: data after body length: %uz", MODULE_NAME,
                 __func__, __LINE__, ctx->body_length);
-
-  if (r->parent != NULL && r != r->parent) {
-    ngx_http_mrb_read_subrequest_responce(r, ctx);
-    return NGX_OK;
-  }
 
   rc = ngx_http_next_header_filter(r);
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -831,9 +831,6 @@ http {
             # if subreqeust_in_memory limit reached(default 4k/8k),
             # increased the memory size by subrequest_output_buffer_size
             proxy_pass http://127.0.0.1:58081/;
-            mruby_output_body_filter_code '
-              Nginx.log Nginx::LOG_INFO, "read subrequest proxy pass"
-            ';
         }
 
         location /async_http_sub_request_with_proxy_pass {
@@ -888,10 +885,6 @@ http {
             mruby_content_handler_code '
               Nginx.rputs Nginx::Request.new.uri_args.inspect
             ';
-            mruby_output_body_filter_code '
-              Nginx.log Nginx::LOG_INFO, "read subrequest body"
-            ';
-
         }
 
         location /async_http_sub_request {


### PR DESCRIPTION
@matsumotory Please review.

sub_requestの本文、ヘッダを取得するために、subrequestのbody filterで取っていたが、request構造体から取れることがわかったので書き直しました。

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
