### PR TITLE
Allow `test.sh` to specify a launcher to start nginx

### DIFF
--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -34,3 +34,8 @@ end
 sh test.sh
 ```
 
+If you want to run with valgrind, set the environment variables `NGINX_RUNNER` and `NGINX_HEATTIME`.
+
+```console
+$ NGINX_RUNNER=valgrind NGINX_HEATTIME=10 sh test.sh
+```

--- a/test.sh
+++ b/test.sh
@@ -119,6 +119,9 @@ do
     fi
 done
 
+: ${NGINX_RUNNER:=exec}
+: ${NGINX_HEATTIME:=2}
+
 echo "====================================="
 echo ""
 echo "ngx_mruby starting and logging"
@@ -126,12 +129,13 @@ echo ""
 echo "====================================="
 echo ""
 echo ""
-${NGINX_INSTALL_DIR}/sbin/nginx &
+${NGINX_RUNNER} ${NGINX_INSTALL_DIR}/sbin/nginx &
+nginx_pid=$!
+trap "kill $nginx_pid; wait" EXIT
 echo ""
 echo ""
-sleep 2 # waiting for nginx
+sleep ${NGINX_HEATTIME} # waiting for nginx
 ./mruby/build/test/bin/mruby ./test/t/ngx_mruby.rb 2> ${NGINX_INSTALL_DIR}/logs/stderr.log
-$KILLALL nginx
 echo "ngx_mruby testing ... Done"
 
 echo "test.sh ... successful"


### PR DESCRIPTION
The purpose is to make valgrind available.

The environment variable `NGINX_RUNNER` allows for specifying the `nginx` launcher.
Also, the environment variable `NGINX_HEATTIME` allows for the time to wait for the test to run.

e.g.

```console
% NGINX_RUNNER=valgrind NGINX_HEATTIME=10 ./test.sh
```

:smile_cat: [ローカル環境で得られた、不穏なログを記録しておきました](https://gist.github.com/dearblue/26a18926bea9dca33ffce2a472da22e8)。
ログを全て確認したわけではありませんが、最初の40行までに報告された二つの問題は無視して大丈夫だと思います。
後の問題は・・・・・・僕は :see_no_evil: 目が :see_no_evil: 悪くて :see_no_evil: よく見えませんでした。

@matsumotory Please review.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [X] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
