### PR TITLE
Improve fiber gc registration

### DIFF
--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -54,6 +54,11 @@ mrb_value ngx_mrb_start_fiber(ngx_http_request_t *r, mrb_state *mrb, struct RPro
     ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
                   "%s NOTICE %s:%d: preparing fiber got the raise, leave the fiber", MODULE_NAME, __func__, __LINE__);
     return mrb_false_value();
+  } else {
+    // keeps the object from GC when can resume the fiber
+    // Don't forget to remove the object using
+    // mrb_gc_unregister, otherwise your object will leak
+    mrb_gc_register(mrb, *fiber_proc);
   }
 
   return ngx_mrb_run_fiber(mrb, fiber_proc, result);
@@ -73,12 +78,14 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber_proc, mrb_value *re
   if (mrb->exc) {
     ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber",
                   MODULE_NAME, __func__, __LINE__);
+    mrb_gc_unregister(re->mrb, *re->fiber);
     return mrb_false_value();
   }
 
   aliving = mrb_fiber_alive_p(mrb, *fiber_proc);
 
   if (!mrb_test(aliving) && result != NULL) {
+    mrb_gc_unregister(re->mrb, *re->fiber);
     *result = handler_result;
   }
 
@@ -197,11 +204,6 @@ static mrb_value ngx_mrb_async_sleep(mrb_state *mrb, mrb_value self)
 
   ctx = ngx_mrb_http_get_module_ctx(mrb, r);
   re->fiber = ctx->fiber_proc;
-
-  // keeps the object from GC when can resume the fiber
-  // Don't forget to remove the object using
-  // mrb_gc_unregister, otherwise your object will leak
-  mrb_gc_register(mrb, *re->fiber);
 
   ev = (ngx_event_t *)p;
   ngx_memzero(ev, sizeof(ngx_event_t));

--- a/src/http/ngx_http_mruby_async.c
+++ b/src/http/ngx_http_mruby_async.c
@@ -78,14 +78,14 @@ mrb_value ngx_mrb_run_fiber(mrb_state *mrb, mrb_value *fiber_proc, mrb_value *re
   if (mrb->exc) {
     ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0, "%s NOTICE %s:%d: fiber got the raise, leave the fiber",
                   MODULE_NAME, __func__, __LINE__);
-    mrb_gc_unregister(re->mrb, *re->fiber);
+    mrb_gc_unregister(mrb, *fiber_proc);
     return mrb_false_value();
   }
 
   aliving = mrb_fiber_alive_p(mrb, *fiber_proc);
 
   if (!mrb_test(aliving) && result != NULL) {
-    mrb_gc_unregister(re->mrb, *re->fiber);
+    mrb_gc_unregister(mrb, *fiber_proc);
     *result = handler_result;
   }
 


### PR DESCRIPTION
Hello!!

@matsumotory Please review.

When repeatedly performing Nginx::Async.sleep, it overflows the value of MRB_ARY_LENGTH_MAX, resulting in the following error.

https://github.com/matsumotory/ngx_mruby/blob/af4228888587680d2c44b0aebbfb91e6e470d219/mruby/src/array.c#L26-L29

The issue also occurs with ngx_mruby v2.5.0.

There might be a misunderstanding on my part, or something missing. Please point out any discrepancies or omissions.

After looking into it, it appears that the error is occurring because mrb_gc_register is executed on every sleep operation. If mrb_gc_register is run at the start of the fiber and mrb_gc_unregister is run at the end of the fiber, the error will no longer occur.

I tried creating a PR. Please check it.

## Pull-Request Check List

- [ ] Add patches into `src/`.
- [ ] Add test into `test/`. Please see about [test docs](https://github.com/matsumotory/ngx_mruby/tree/master/docs/test).
- [ ] Add docs into `docs/` if you change the features such as [build system](https://github.com/matsumotory/ngx_mruby/tree/master/docs/install), [Ruby methods, class](https://github.com/matsumotory/ngx_mruby/tree/master/docs/class_and_method) and [nginx directives](https://github.com/matsumotory/ngx_mruby/tree/master/docs/directives).
